### PR TITLE
add debug option to smoke test

### DIFF
--- a/tests/discord-bot-smoke-test.py
+++ b/tests/discord-bot-smoke-test.py
@@ -36,6 +36,7 @@ parser = argparse.ArgumentParser(
     - The smoke test does not yet work for Modal runs.""",
     formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument('message_url', type=str, help='Discord message URL to test')
+parser.add_argument('--debug', action='store_true', help='Run in debug/staging mode')
 args = parser.parse_args()
 
 message_id = int(args.message_url.split('/')[-1])
@@ -134,10 +135,14 @@ async def on_ready():
 if __name__ == '__main__':
     logger.info("Running smoke tests...")
 
-    token = os.getenv('DISCORD_TOKEN')
-    if not token:
-        logger.error('DISCORD_TOKEN environment variable not set.')
-        exit(1)
+    if args.debug:
+        token = os.getenv('DISCORD_DEBUG_TOKEN')
+        if not token:
+            raise ValueError("DISCORD_DEBUG_TOKEN not found")
+    else:
+        token = os.getenv('DISCORD_TOKEN')
+        if not token:
+            raise ValueError("DISCORD_TOKEN not found")
 
     client.run(token)
 


### PR DESCRIPTION
## Description

Siro noticed that the smoke test was always grabbing the Discord token and didn't have an option to grab the Discord debug token. This change gives the smoke test a `--debug` option which, if set, grabs the debug token. This makes the smoke test act in the same way as the bot when the debug option is given on the command line.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the smoke test on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start a training run by with the slash command `/run`.
    You may need to exercise some judgement about the script and GPU type.
  - Wait for the training run to complete.
  - Copy the URL for the thread started by the cluster bot in response to
    your `/run` message ("Cluster Bot started a thread: ..."):
      - Click on the 3 dots (`...`) to the cluster bot's message.
      - Select *Copy Message Link*.
  - Using the copied URL, run the smoke test:
    ```bash
    python discord-bot-smoke-test.py copied_url
    ```
  - Verify that the smoke test script responds with:
    ```
    All tests passed!
    ```
  For more information on running a cluster bot on your own server, see
  README.md.
