### PR TITLE
add /verifyruns cog

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -14,6 +14,7 @@ from consts import (
 )
 from cogs.modal_cog import ModalCog
 from cogs.github_cog import GitHubCog
+from cogs.verify_run_cog import VerifyRunCog
 
 logger = setup_logging()
 
@@ -38,6 +39,7 @@ class ClusterBot(commands.Bot):
             await self.add_cog(ModalCog(self))
             await self.add_cog(GitHubCog(self))
             await self.add_cog(BotManagerCog(self))
+            await self.add_cog(VerifyRunCog(self))
 
             guild_id = (
                 DISCORD_CLUSTER_STAGING_ID

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -35,6 +35,7 @@ class GitHubCog(commands.Cog):
         interaction: discord.Interaction,
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
+        use_followup: bool = False
     ):
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
             await interaction.response.send_message(
@@ -43,10 +44,15 @@ class GitHubCog(commands.Cog):
             return
 
         thread = await self.bot.create_thread(interaction, gpu_type.name, "GitHub Job")
+        message = f"Created thread {thread.mention} for your GitHub job"
 
-        await interaction.response.send_message(
-            f"Created thread {thread.mention} for your GitHub job"
-        )
+        if use_followup:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
+            await interaction.followup.send(message)
+        else:
+            await interaction.response.send_message(message)
+
         await thread.send(f"Processing `{script.filename}` with {gpu_type.name}...")
 
         try:

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -47,8 +47,6 @@ class GitHubCog(commands.Cog):
         message = f"Created thread {thread.mention} for your GitHub job"
 
         if use_followup:
-            if not interaction.response.is_done():
-                await interaction.response.defer()
             await interaction.followup.send(message)
         else:
             await interaction.response.send_message(message)

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -36,12 +36,12 @@ class GitHubCog(commands.Cog):
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
         use_followup: bool = False
-    ):
+    ) -> discord.Thread:
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
             await interaction.response.send_message(
                 "Please provide a Python (.py) or CUDA (.cu) file"
             )
-            return
+            return None
 
         thread = await self.bot.create_thread(interaction, gpu_type.name, "GitHub Job")
         message = f"Created thread {thread.mention} for your GitHub job"
@@ -85,6 +85,9 @@ class GitHubCog(commands.Cog):
         except Exception as e:
             logger.error(f"Error processing request: {str(e)}", exc_info=True)
             await thread.send(f"Error processing request: {str(e)}")
+
+        finally:
+            return thread
 
     async def trigger_github_action(self, script_content, filename, gpu_type):
         logger.info(f"Attempting to trigger GitHub action for {gpu_type.name} GPU")

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -30,12 +30,12 @@ class ModalCog(commands.Cog):
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
         use_followup: bool = False
-    ):
+    ) -> discord.Thread:
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
             await interaction.response.send_message(
                 "Please provide a Python (.py) or CUDA (.cu) file"
             )
-            return
+            return None
 
         thread = await self.bot.create_thread(interaction, gpu_type.name, "Modal Job")
         message = f"Created thread {thread.mention} for your Modal job"
@@ -57,6 +57,8 @@ class ModalCog(commands.Cog):
         except Exception as e:
             logger.error(f"Error processing request: {str(e)}", exc_info=True)
             await thread.send(f"Error processing request: {str(e)}")
+        finally:
+            return thread
 
     async def trigger_modal_run(self, script_content: str, filename: str) -> str:
         logger.info("Attempting to trigger Modal run")

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -43,8 +43,6 @@ class ModalCog(commands.Cog):
         message = f"Created thread {thread.mention} for your Modal job"
 
         if use_followup:
-            if not interaction.response.is_done():
-                await interaction.response.defer()
             await interaction.followup.send(message)
         else:
             await interaction.response.send_message(message)

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -29,6 +29,7 @@ class ModalCog(commands.Cog):
         interaction: discord.Interaction,
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
+        use_followup: bool = False
     ):
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
             await interaction.response.send_message(
@@ -37,10 +38,15 @@ class ModalCog(commands.Cog):
             return
 
         thread = await self.bot.create_thread(interaction, gpu_type.name, "Modal Job")
+        message = f"Created thread {thread.mention} for your Modal job"
 
-        await interaction.response.send_message(
-            f"Created thread {thread.mention} for your Modal job"
-        )
+        if use_followup:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
+            await interaction.followup.send(message)
+        else:
+            await interaction.response.send_message(message)
+
         await thread.send(f"Processing `{script.filename}` with {gpu_type.name}...")
 
         try:

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -3,8 +3,19 @@ from discord import app_commands
 from discord.ext import commands
 import re
 from utils import setup_logging
+from unittest.mock import AsyncMock
 
 logger = setup_logging()
+
+def create_mock_attachment(filename: str, content: str):
+    "Create an AsyncMock to simulate discord.Attachment"
+
+    mock_attachment = AsyncMock(spec=discord.Attachment)
+    mock_attachment.filename = filename
+    mock_attachment.content_type = 'text/plain'
+    # Simulate the read method
+    mock_attachment.read = AsyncMock(return_value=content.encode('utf-8'))
+    return mock_attachment
 
 class VerifyRunCog(commands.Cog):
     """
@@ -101,3 +112,43 @@ class VerifyRunCog(commands.Cog):
             await self.verify_modal_run(interaction, message_contents)
         else:
             await interaction.response.send_message("❌ Could not determine run type!")
+    
+    @app_commands.command(name='verifyrun2')
+    async def verify_run2(self, interaction: discord.Interaction):
+        """Verify runs on on Modal, GitHub Nvidia, and GitHub AMD."""
+
+        try:
+            # Get instances of the other cogs
+            modal_cog = self.bot.get_cog('ModalCog')
+            github_cog = self.bot.get_cog('GitHubCog')
+
+            if not all([modal_cog, github_cog]):
+                await interaction.followup.send("❌ Required cogs not found!")
+                return
+
+            script_content = "print('Hello, world!')"
+            script_file = create_mock_attachment("test_script.py", script_content)
+
+            t4 = app_commands.Choice(name="NVIDIA T4", value="t4")
+            nvidia = app_commands.Choice(name="NVIDIA", value="nvidia")
+            amd = app_commands.Choice(name="AMD", value="amd")
+
+            modal_command = modal_cog.run_modal
+            await modal_command.callback(modal_cog, interaction, script_file, t4, use_followup=True)
+
+            github_command = github_cog.run_github
+            await github_command.callback(github_cog, interaction, script_file, nvidia, use_followup=True)
+            await github_command.callback(github_cog, interaction, script_file, amd, use_followup=True)
+
+            await interaction.followup.send(
+               "✅ Started all verification runs:\n"
+               "- Modal run\n"
+               "- GitHub Nvidia run\n"
+               "- GitHub AMD run"
+            )
+
+        except Exception as e:
+            logger.error(f"Error starting verification runs: {e}", exc_info=True)
+            await interaction.followup.send(
+                f"❌ Error starting verification runs: {str(e)}"
+            )

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -56,7 +56,7 @@ class VerifyRunCog(commands.Cog):
 
         all_patterns_found = all(
             any(
-                re.match(pattern, content, re.DOTALL) != None
+                re.search(pattern, content, re.DOTALL) != None
                 for content in message_contents
             )
             for pattern in required_patterns
@@ -69,7 +69,7 @@ class VerifyRunCog(commands.Cog):
         else:
             missing_patterns = [
                 pattern for pattern in required_patterns
-                if not any(re.match(pattern, content, re.DOTALL) 
+                if not any(re.search(pattern, content, re.DOTALL) 
                            for content in message_contents)
             ]
             await interaction.followup.send(
@@ -94,11 +94,11 @@ class VerifyRunCog(commands.Cog):
         required_patterns = [
             "Processing `.*` with",
             "Running on Modal...",
-            ".*```\nModal execution result:",
+            "Modal execution result:",
         ]
 
         all_patterns_found = all(
-            any(re.match(pattern, content, re.DOTALL) != None
+            any(re.search(pattern, content, re.DOTALL) != None
                  for content in message_contents)
             for pattern in required_patterns
         )
@@ -110,7 +110,7 @@ class VerifyRunCog(commands.Cog):
         else:
             missing_patterns = [
                 pattern for pattern in required_patterns
-                if not any(re.match(pattern, content, re.DOTALL)
+                if not any(re.search(pattern, content, re.DOTALL)
                            for content in message_contents)
             ]
             await interaction.followup.send(

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -124,6 +124,9 @@ class VerifyRunCog(commands.Cog):
         """Verify runs on on Modal, GitHub Nvidia, and GitHub AMD."""
 
         try:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
+
             modal_cog = self.bot.get_cog('ModalCog')
             github_cog = self.bot.get_cog('GitHubCog')
 

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -1,0 +1,103 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+import re
+from utils import setup_logging
+
+logger = setup_logging()
+
+class VerifyRunCog(commands.Cog):
+    """
+    A Discord cog for verifying the success of trainingruns.
+
+    This cog provides functionality to verify that either a GitHub Actions or
+    Modal run completed successfully by checking for specific message patterns
+    in a Discord thread. It supports verification of two types of runs:
+    1. GitHub Actions runs - Identified by "GitHub Action triggered!" message
+    2. Modal runs - Identified by "Running on Modal..." message
+
+    Commands:
+        /verifyrun: Verifies the success of a run in the current thread. Can
+            only be used in a thread. Automatically detects the run type and
+            applies appropriate verification.
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def verify_github_run(self, interaction: discord.Interaction, message_contents: list[str]):
+        """Verify that a GitHub Actions run completed successfully"""
+
+        required_patterns = [
+            "Processing `.*` with",
+            "GitHub Action triggered! Run ID:",
+            "Training completed with status: success",
+            ".*```\nLogs.*:",
+            "View the full run at:",
+        ]
+
+        all_patterns_found = all(
+            any(
+                re.match(pattern, content, re.DOTALL) != None
+                for content in message_contents
+            )
+            for pattern in required_patterns
+        )
+
+        if all_patterns_found:
+            await interaction.response.send_message(
+                "✅ All expected messages found - run completed successfully!")
+        else:
+            missing_patterns = [
+                pattern for pattern in required_patterns
+                if not any(re.match(pattern, content, re.DOTALL) for content in message_contents)
+            ]
+            await interaction.response.send_message(
+                "❌ Run verification failed. Missing expected messages:\n" +
+                "\n".join(f"- {pattern}" for pattern in missing_patterns)
+            )
+
+    async def verify_modal_run(self, interaction: discord.Interaction, message_contents: list[str]):
+        """Verify that a Modal run completed successfully"""
+
+        required_patterns = [
+            "Processing `.*` with",
+            "Running on Modal...",
+            ".*```\nModal execution result:",
+        ]
+
+        all_patterns_found = all(
+            any(re.match(pattern, content, re.DOTALL) != None for content in message_contents)
+            for pattern in required_patterns
+        )
+
+        if all_patterns_found:
+            await interaction.response.send_message("✅ All expected messages found - Modal run completed successfully!")
+        else:
+            missing_patterns = [
+                pattern for pattern in required_patterns
+                if not any(re.match(pattern, content, re.DOTALL) for content in message_contents)
+            ]
+            await interaction.response.send_message(
+                "❌ Modal run verification failed. Missing expected messages:\n" +
+                "\n".join(f"- {pattern}" for pattern in missing_patterns)
+            )
+
+    @app_commands.command(name='verifyrun')
+    async def verify_run(self, interaction: discord.Interaction):
+        """Verify that a run in the current thread completed successfully"""
+
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message("This command can only be used in a thread!")
+            return
+
+        message_contents = [msg.content async for msg in interaction.channel.history(limit=None)]
+
+        # Check for GitHub Action run
+        if any("GitHub Action triggered!" in content for content in message_contents):
+            await self.verify_github_run(interaction, message_contents)
+        # Check for Modal run
+        elif any("Running on Modal..." in content for content in message_contents):
+            await self.verify_modal_run(interaction, message_contents)
+        else:
+            await interaction.response.send_message("❌ Could not determine run type!")

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -1,43 +1,50 @@
+import re
+import asyncio
 import discord
 from discord import app_commands
 from discord.ext import commands
-import re
-from utils import setup_logging
 from unittest.mock import AsyncMock
+from utils import setup_logging
+from cogs.modal_cog import ModalCog
+from cogs.github_cog import GitHubCog
 
 logger = setup_logging()
 
-def create_mock_attachment(filename: str, content: str):
+def create_mock_attachment():
     "Create an AsyncMock to simulate discord.Attachment"
 
     mock_attachment = AsyncMock(spec=discord.Attachment)
-    mock_attachment.filename = filename
+    mock_attachment.filename = "test_script.py"
     mock_attachment.content_type = 'text/plain'
-    # Simulate the read method
-    mock_attachment.read = AsyncMock(return_value=content.encode('utf-8'))
+    mock_attachment.read = AsyncMock(
+        return_value="print('Hello, world!')".encode('utf-8'))
     return mock_attachment
+
+script_file = create_mock_attachment()
 
 class VerifyRunCog(commands.Cog):
     """
-    A Discord cog for verifying the success of trainingruns.
+    A Discord cog for verifying the success of training runs.
 
-    This cog provides functionality to verify that either a GitHub Actions or
-    Modal run completed successfully by checking for specific message patterns
-    in a Discord thread. It supports verification of two types of runs:
-    1. GitHub Actions runs - Identified by "GitHub Action triggered!" message
-    2. Modal runs - Identified by "Running on Modal..." message
-
-    Commands:
-        /verifyrun: Verifies the success of a run in the current thread. Can
-            only be used in a thread. Automatically detects the run type and
-            applies appropriate verification.
+    A cog that verifies training runs across different platforms and GPU types.
+    Runs test scripts on GitHub (Nvidia and AMD) and Modal to validate that the
+    runs complete successfully. Each run is monitored for expected output
+    messages.
     """
 
     def __init__(self, bot):
         self.bot = bot
 
-    async def verify_github_run(self, interaction: discord.Interaction, message_contents: list[str]):
-        """Verify that a GitHub Actions run completed successfully"""
+    async def verify_github_run(
+            self, github_cog: GitHubCog,
+            choice: app_commands.Choice,
+            interaction: discord.Interaction):
+
+        github_command = github_cog.run_github
+        github_thread = await github_command.callback(
+            github_cog, interaction, script_file, choice, use_followup=True)
+
+        message_contents = [msg.content async for msg in github_thread.history(limit=None)]
 
         required_patterns = [
             "Processing `.*` with",
@@ -56,20 +63,31 @@ class VerifyRunCog(commands.Cog):
         )
 
         if all_patterns_found:
-            await interaction.response.send_message(
-                "✅ All expected messages found - run completed successfully!")
+            await interaction.followup.send(
+                f"✅ GitHub run ({choice.name}) completed successfully - all expected messages found!")
         else:
             missing_patterns = [
                 pattern for pattern in required_patterns
-                if not any(re.match(pattern, content, re.DOTALL) for content in message_contents)
+                if not any(re.match(pattern, content, re.DOTALL) 
+                           for content in message_contents)
             ]
-            await interaction.response.send_message(
-                "❌ Run verification failed. Missing expected messages:\n" +
+            await interaction.followup.send(
+                f"❌ GitHub run ({choice.name}) verification failed. Missing expected messages:\n" +
                 "\n".join(f"- {pattern}" for pattern in missing_patterns)
             )
 
-    async def verify_modal_run(self, interaction: discord.Interaction, message_contents: list[str]):
-        """Verify that a Modal run completed successfully"""
+    async def verify_modal_run(
+            self,
+            modal_cog: ModalCog,
+            interaction: discord.Interaction):
+
+        t4 = app_commands.Choice(name="NVIDIA T4", value="t4")
+        modal_command = modal_cog.run_modal
+
+        modal_thread = await modal_command.callback(
+            modal_cog, interaction, script_file, t4, use_followup=True)
+
+        message_contents = [msg.content async for msg in modal_thread.history(limit=None)]
 
         required_patterns = [
             "Processing `.*` with",
@@ -78,74 +96,44 @@ class VerifyRunCog(commands.Cog):
         ]
 
         all_patterns_found = all(
-            any(re.match(pattern, content, re.DOTALL) != None for content in message_contents)
+            any(re.match(pattern, content, re.DOTALL) != None
+                 for content in message_contents)
             for pattern in required_patterns
         )
 
         if all_patterns_found:
-            await interaction.response.send_message("✅ All expected messages found - Modal run completed successfully!")
+            await interaction.followup.send(
+                "✅ Modal run completed successfully - all expected messages found!")
         else:
             missing_patterns = [
                 pattern for pattern in required_patterns
-                if not any(re.match(pattern, content, re.DOTALL) for content in message_contents)
+                if not any(re.match(pattern, content, re.DOTALL)
+                           for content in message_contents)
             ]
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "❌ Modal run verification failed. Missing expected messages:\n" +
                 "\n".join(f"- {pattern}" for pattern in missing_patterns)
             )
 
-    @app_commands.command(name='verifyrun')
-    async def verify_run(self, interaction: discord.Interaction):
-        """Verify that a run in the current thread completed successfully"""
-
-        if not isinstance(interaction.channel, discord.Thread):
-            await interaction.response.send_message("This command can only be used in a thread!")
-            return
-
-        message_contents = [msg.content async for msg in interaction.channel.history(limit=None)]
-
-        # Check for GitHub Action run
-        if any("GitHub Action triggered!" in content for content in message_contents):
-            await self.verify_github_run(interaction, message_contents)
-        # Check for Modal run
-        elif any("Running on Modal..." in content for content in message_contents):
-            await self.verify_modal_run(interaction, message_contents)
-        else:
-            await interaction.response.send_message("❌ Could not determine run type!")
-    
-    @app_commands.command(name='verifyrun2')
-    async def verify_run2(self, interaction: discord.Interaction):
+    @app_commands.command(name='verifyruns')
+    async def verify_runs(self, interaction: discord.Interaction):
         """Verify runs on on Modal, GitHub Nvidia, and GitHub AMD."""
 
         try:
-            # Get instances of the other cogs
             modal_cog = self.bot.get_cog('ModalCog')
             github_cog = self.bot.get_cog('GitHubCog')
 
             if not all([modal_cog, github_cog]):
-                await interaction.followup.send("❌ Required cogs not found!")
+                await interaction.response.send_message("❌ Required cogs not found!")
                 return
 
-            script_content = "print('Hello, world!')"
-            script_file = create_mock_attachment("test_script.py", script_content)
-
-            t4 = app_commands.Choice(name="NVIDIA T4", value="t4")
             nvidia = app_commands.Choice(name="NVIDIA", value="nvidia")
             amd = app_commands.Choice(name="AMD", value="amd")
 
-            modal_command = modal_cog.run_modal
-            await modal_command.callback(modal_cog, interaction, script_file, t4, use_followup=True)
-
-            github_command = github_cog.run_github
-            await github_command.callback(github_cog, interaction, script_file, nvidia, use_followup=True)
-            await github_command.callback(github_cog, interaction, script_file, amd, use_followup=True)
-
-            await interaction.followup.send(
-               "✅ Started all verification runs:\n"
-               "- Modal run\n"
-               "- GitHub Nvidia run\n"
-               "- GitHub AMD run"
-            )
+            await asyncio.gather(
+                self.verify_github_run(github_cog, nvidia, interaction),
+                self.verify_github_run(github_cog, amd, interaction),
+                self.verify_modal_run(modal_cog, interaction))
 
         except Exception as e:
             logger.error(f"Error starting verification runs: {e}", exc_info=True)


### PR DESCRIPTION
## Description

Adds a `/verifyrun` command that does the same work as the smoke test but is easier to use.

![image](https://github.com/user-attachments/assets/3aa2fb15-b68f-4df8-b25c-c92663524190)

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the smoke test on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start a training run by with the slash command `/run`.
    You may need to exercise some judgement about the script and GPU type.
  - Wait for the training run to complete.
  - Copy the URL for the thread started by the cluster bot in response to
    your `/run` message ("Cluster Bot started a thread: ..."):
      - Click on the 3 dots (`...`) to the cluster bot's message.
      - Select *Copy Message Link*.
  - Using the copied URL, run the smoke test:
    ```bash
    python discord-bot-smoke-test.py copied_url
    ```
  - Verify that the smoke test script responds with:
    ```
    All tests passed!
    ```
  For more information on running a cluster bot on your own server, see
  README.md.
