### PR TITLE
Add GitHub (NVIDIA / AMD) Runners to /leaderboard submit and allow Leaderboard Submissions

### DIFF
--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -11,6 +11,22 @@ on:
         description: 'Name of Python script'
         required: true
         type: string
+      reference_content:
+        description: 'Content of the reference code script (optional)'
+        required: false
+        type: string
+      reference_filename:
+        description: 'Name of reference script (supports .py or .cu)'
+        required: false
+        type: string
+      eval_content:
+        description: 'Content of the outer eval code script (optional)'
+        required: false
+        type: string
+      eval_filename:
+        description: 'Name of outer eval script (supports .py or .cu)'
+        required: false
+        type: string
 
 jobs:
   train:
@@ -30,6 +46,32 @@ jobs:
         with open('${{ github.event.inputs.filename }}', 'w') as f:
             f.write('''${{ github.event.inputs.script_content }}''')
 
+    - name: Create reference scripts if provided
+      shell: bash
+      run: |
+        if [[ -n "${{ github.event.inputs.reference_filename }}" ]]; then
+          echo "Creating reference script..."
+          cat > "${{ github.event.inputs.reference_filename }}" <<EOL
+        ${{ github.event.inputs.reference_content }}
+        EOL
+            cat "${{ github.event.inputs.reference_filename }}"  # Debug: Show file contents
+          else
+              echo "No reference content provided."
+          fi
+
+    - name: Create eval scripts if provided
+      shell: bash
+      run: |
+        if [[ -n "${{ github.event.inputs.eval_filename }}" ]]; then
+          echo "Creating reference script..."
+          cat > "${{ github.event.inputs.eval_filename }}" <<EOL
+        ${{ github.event.inputs.eval_content }}
+        EOL
+            cat "${{ github.event.inputs.eval_filename }}"  # Debug: Show file contents
+          else
+              echo "No eval content provided."
+          fi
+
     - name: Setup Virtual Environment and Install Dependencies
       run: |
         python -m venv ${VENV_DIR}
@@ -38,8 +80,26 @@ jobs:
         pip install --pre pytorch-triton-rocm==3.1.0+cf34004b8a torch==2.6.0.dev20241023+rocm6.2 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
 
     - name: Run script
+      shell: bash
       run: |
-        python "${{ github.event.inputs.filename }}" > training.log 2>&1
+        if [[ -n "${{ github.event.inputs.eval_content }}" ]]; then
+          echo "Running Python file..."
+          python3 "${{ github.event.inputs.eval_filename }}" > training.log 2>&1
+          cat training.log  # Debug: show output
+        else
+          echo "Running Python file..."
+          python3 "${{ github.event.inputs.filename }}" > training.log 2>&1
+          cat training.log  # Debug: show output
+        fi
+
+    - name: Extract score
+      shell: bash
+      run: |
+        # Extract only the last occurrence of "score:"
+        score=$(grep -oP 'score:\s*\d+(\.\d+)?' training.log | tail -n 1 | awk '{print $2}')
+
+        echo "Score extracted: $score"
+        echo "::set-output name=score::$score"
 
     - name: Upload training artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -10,6 +10,14 @@ on:
         description: 'Name of script (supports .py or .cu)'
         required: true
         type: string
+      reference_content:
+        description: 'Content of the reference code script (optional)'
+        required: false
+        type: string
+      reference_filename:
+        description: 'Name of reference script (supports .py or .cu)'
+        required: false
+        type: string
 
 jobs:
   train:
@@ -40,7 +48,16 @@ jobs:
           ${{ github.event.inputs.script_content }}
           EOL
           cat ${{ github.event.inputs.filename }}  # Debug: show file contents
-          
+
+      - name: Create eval and reference scripts if provided
+        run: |
+          if [[ -n "${{ github.event.inputs.reference_content }}" ]]; then
+            echo "Creating reference script..."
+            cat << 'EOL' > ${{ github.event.inputs.reference_filename }}
+            ${{ github.event.inputs.reference_content }}
+            EOL
+            cat ${{ github.event.inputs.reference_filename }}
+          fi
       - name: Install dependencies
         run: |
           if grep -rE "(import torch|from torch)" "${{ github.event.inputs.filename }}"; then
@@ -55,15 +72,27 @@ jobs:
       - name: Run script
         shell: bash
         run: |
-          if [[ "${{ github.event.inputs.filename }}" == *.cu ]]; then
-            echo "Compiling and running CUDA file..."
-            nvcc "${{ github.event.inputs.filename }}" -o cuda_program
-            ./cuda_program > training.log 2>&1
+          if [[ -n "${{ github.event.inputs.reference_content }}" ]]; then
+            if [[ "${{ github.event.inputs.reference_filename }}" == *.cu ]]; then
+              echo "Compiling and running CUDA file..."
+              nvcc "${{ github.event.inputs.reference_filename }}" -o cuda_program
+              ./cuda_program > training.log 2>&1
+            else
+              echo "Running Python file..."
+              python3 "${{ github.event.inputs.reference_filename }}" > training.log 2>&1
+            fi
+            cat training.log  # Debug: show output
           else
-            echo "Running Python file..."
-            python3 "${{ github.event.inputs.filename }}" > training.log 2>&1
+            if [[ "${{ github.event.inputs.filename }}" == *.cu ]]; then
+              echo "Compiling and running CUDA file..."
+              nvcc "${{ github.event.inputs.filename }}" -o cuda_program
+              ./cuda_program > training.log 2>&1
+            else
+              echo "Running Python file..."
+              python3 "${{ github.event.inputs.filename }}" > training.log 2>&1
+            fi
+            cat training.log  # Debug: show output
           fi
-          cat training.log  # Debug: show output
 
       - name: Upload training artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -59,16 +59,16 @@ jobs:
           cat ${{ github.event.inputs.filename }}  # Debug: show file contents
 
       - name: Create reference scripts if provided
-        shell: bash
         run: |
           if [[ -n "${{ github.event.inputs.reference_content }}" ]]; then
             echo "Creating reference script..."
-            cat << 'EOL' > ${{ github.event.inputs.reference_filename }}
-            ${{ github.event.inputs.reference_content }}
-            EOL
-            cat ${{ github.event.inputs.reference_filename }}
-          fi
-
+            cat > "${{ github.event.inputs.reference_filename }}" <<EOL
+          ${{ github.event.inputs.reference_content }}
+          EOL
+              cat "${{ github.event.inputs.reference_filename }}"  # Debug: Show file contents
+            else
+                echo "No reference content provided."
+            fi
 
       - name: Create eval scripts if provided
         shell: bash

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -18,6 +18,14 @@ on:
         description: 'Name of reference script (supports .py or .cu)'
         required: false
         type: string
+      eval_content:
+        description: 'Content of the outer eval code script (optional)'
+        required: false
+        type: string
+      eval_filename:
+        description: 'Name of outer eval script (supports .py or .cu)'
+        required: false
+        type: string
 
 jobs:
   train:
@@ -43,13 +51,15 @@ jobs:
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
           
       - name: Create script file
+        shell: bash
         run: |
           cat << 'EOL' > ${{ github.event.inputs.filename }}
           ${{ github.event.inputs.script_content }}
           EOL
           cat ${{ github.event.inputs.filename }}  # Debug: show file contents
 
-      - name: Create eval and reference scripts if provided
+      - name: Create reference scripts if provided
+        shell: bash
         run: |
           if [[ -n "${{ github.event.inputs.reference_content }}" ]]; then
             echo "Creating reference script..."
@@ -58,6 +68,19 @@ jobs:
             EOL
             cat ${{ github.event.inputs.reference_filename }}
           fi
+
+
+      - name: Create eval scripts if provided
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.eval_content }}" ]]; then
+            echo "Creating eval script..."
+            cat << 'EOL' > ${{ github.event.inputs.eval_filename }}
+            ${{ github.event.inputs.eval_content }}
+            EOL
+            cat ${{ github.event.inputs.eval_filename }}
+          fi
+
       - name: Install dependencies
         run: |
           if grep -rE "(import torch|from torch)" "${{ github.event.inputs.filename }}"; then
@@ -72,14 +95,14 @@ jobs:
       - name: Run script
         shell: bash
         run: |
-          if [[ -n "${{ github.event.inputs.reference_content }}" ]]; then
-            if [[ "${{ github.event.inputs.reference_filename }}" == *.cu ]]; then
+          if [[ -n "${{ github.event.inputs.eval_content }}" ]]; then
+            if [[ "${{ github.event.inputs.eval_content }}" == *.cu ]]; then
               echo "Compiling and running CUDA file..."
-              nvcc "${{ github.event.inputs.reference_filename }}" -o cuda_program
+              nvcc "${{ github.event.inputs.eval_filename }}" -o cuda_program
               ./cuda_program > training.log 2>&1
             else
               echo "Running Python file..."
-              python3 "${{ github.event.inputs.reference_filename }}" > training.log 2>&1
+              python3 "${{ github.event.inputs.eval_filename }}" > training.log 2>&1
             fi
             cat training.log  # Debug: show output
           else
@@ -93,6 +116,15 @@ jobs:
             fi
             cat training.log  # Debug: show output
           fi
+
+      - name: Extract score
+        shell: bash
+        run: |
+          # Extract only the last occurrence of "score:"
+          score=$(grep -oP 'score:\s*\d+(\.\d+)?' training.log | tail -n 1 | awk '{print $2}')
+
+          echo "Score extracted: $score"
+          echo "::set-output name=score::$score"
 
       - name: Upload training artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create reference scripts if provided
         run: |
-          if [[ -n "${{ github.event.inputs.reference_content }}" ]]; then
+          if [[ -n "${{ github.event.inputs.reference_filename }}" ]]; then
             echo "Creating reference script..."
             cat > "${{ github.event.inputs.reference_filename }}" <<EOL
           ${{ github.event.inputs.reference_content }}
@@ -73,13 +73,15 @@ jobs:
       - name: Create eval scripts if provided
         shell: bash
         run: |
-          if [[ -n "${{ github.event.inputs.eval_content }}" ]]; then
-            echo "Creating eval script..."
-            cat << 'EOL' > ${{ github.event.inputs.eval_filename }}
-            ${{ github.event.inputs.eval_content }}
-            EOL
-            cat ${{ github.event.inputs.eval_filename }}
-          fi
+          if [[ -n "${{ github.event.inputs.eval_filename }}" ]]; then
+            echo "Creating reference script..."
+            cat > "${{ github.event.inputs.eval_filename }}" <<EOL
+          ${{ github.event.inputs.eval_content }}
+          EOL
+              cat "${{ github.event.inputs.eval_filename }}"  # Debug: Show file contents
+            else
+                echo "No eval content provided."
+            fi
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: |
           if [[ -n "${{ github.event.inputs.eval_filename }}" ]]; then
-            echo "Creating reference script..."
+            echo "Creating eval script..."
             cat > "${{ github.event.inputs.eval_filename }}" <<EOL
           ${{ github.event.inputs.eval_content }}
           EOL

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -59,6 +59,7 @@ jobs:
           cat ${{ github.event.inputs.filename }}  # Debug: show file contents
 
       - name: Create reference scripts if provided
+        shell: bash
         run: |
           if [[ -n "${{ github.event.inputs.reference_filename }}" ]]; then
             echo "Creating reference script..."

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 __pycache__/
+data/
 *.pyc
 .DS_Store
 node_modules/

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -62,12 +62,13 @@ class GitHubCog(commands.Cog):
 
             if use_leaderboard_eval:
                 reference_content = (await reference_script.read()).decode("utf-8")
-                # eval_code = py_eval if script.filename.endswith(".py") else cu_eval
+                eval_code = py_eval if script.filename.endswith(".py") else cu_eval
                 run_id = await self.trigger_github_action(
                     script_content,
                     script.filename,
                     selected_gpu,
                     reference_content,
+                    eval_code,
                 )
             else:
                 run_id = await self.trigger_github_action(
@@ -107,6 +108,7 @@ class GitHubCog(commands.Cog):
         filename,
         gpu_type,
         reference_content=None,
+        eval_content=None,
     ):
         logger.info(f"Attempting to trigger GitHub action for {gpu_type.name} GPU")
         gh = Github(GITHUB_TOKEN)
@@ -118,8 +120,10 @@ class GitHubCog(commands.Cog):
             workflow = repo.get_workflow(workflow_file)
 
             if reference_content is None:
-                # eval_filename = "eval.py" if filename.endswith(".py") else "eval.cu"
-                reference_filename = "ref.py" if filename.endswith(".py") else "ref.cu"
+                eval_filename = "eval.py" if filename.endswith(".py") else "eval.cu"
+                reference_filename = (
+                    "reference.py" if filename.endswith(".py") else "reference.cu"
+                )
                 success = workflow.create_dispatch(
                     get_github_branch_name(),
                     {
@@ -127,6 +131,8 @@ class GitHubCog(commands.Cog):
                         "filename": filename,
                         "reference_content": reference_content,
                         "reference_filename": reference_filename,
+                        "eval_content": eval_content,
+                        "eval_filename": eval_filename,
                     },
                 )
             else:

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -38,6 +38,7 @@ class GitHubCog(commands.Cog):
         gpu_type: app_commands.Choice[str],
         use_followup: bool = False,
         reference_script: discord.Attachment = None,
+        reference_code: str = None,
     ) -> discord.Thread:
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
             await interaction.response.send_message(
@@ -59,8 +60,12 @@ class GitHubCog(commands.Cog):
             script_content = (await script.read()).decode("utf-8")
             selected_gpu = GPUType.AMD if gpu_type.value == "amd" else GPUType.NVIDIA
 
-            if reference_script is not None:
-                reference_content = (await reference_script.read()).decode("utf-8")
+            if reference_script is not None or reference_code is not None:
+                reference_content = (
+                    reference_code
+                    if reference_code is not None
+                    else (await reference_script.read()).decode("utf-8")
+                )
                 eval_code = py_eval if script.filename.endswith(".py") else cu_eval
 
                 run_id = await self.trigger_github_action(

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -37,7 +37,6 @@ class GitHubCog(commands.Cog):
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
         use_followup: bool = False,
-        use_leaderboard_eval: bool = False,
         reference_script: discord.Attachment = None,
     ) -> discord.Thread:
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
@@ -60,13 +59,9 @@ class GitHubCog(commands.Cog):
             script_content = (await script.read()).decode("utf-8")
             selected_gpu = GPUType.AMD if gpu_type.value == "amd" else GPUType.NVIDIA
 
-            if use_leaderboard_eval:
+            if reference_script is not None:
                 reference_content = (await reference_script.read()).decode("utf-8")
-
                 eval_code = py_eval if script.filename.endswith(".py") else cu_eval
-
-                print(reference_content)
-                print(eval_code)
 
                 run_id = await self.trigger_github_action(
                     script_content,

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -62,7 +62,12 @@ class GitHubCog(commands.Cog):
 
             if use_leaderboard_eval:
                 reference_content = (await reference_script.read()).decode("utf-8")
+
                 eval_code = py_eval if script.filename.endswith(".py") else cu_eval
+
+                print(reference_content)
+                print(eval_code)
+
                 run_id = await self.trigger_github_action(
                     script_content,
                     script.filename,
@@ -119,7 +124,7 @@ class GitHubCog(commands.Cog):
             workflow_file = gpu_type.value
             workflow = repo.get_workflow(workflow_file)
 
-            if reference_content is None:
+            if reference_content is not None:
                 eval_filename = "eval.py" if filename.endswith(".py") else "eval.cu"
                 reference_filename = (
                     "reference.py" if filename.endswith(".py") else "reference.cu"

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -9,6 +9,7 @@ import os
 from github import Github
 from utils import setup_logging, get_github_branch_name
 from consts import GPUType, GITHUB_TOKEN, GITHUB_REPO
+from leaderboard_eval import py_eval, cu_eval
 
 logger = setup_logging()
 
@@ -35,7 +36,9 @@ class GitHubCog(commands.Cog):
         interaction: discord.Interaction,
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
-        use_followup: bool = False
+        use_followup: bool = False,
+        use_leaderboard_eval: bool = False,
+        reference_script: discord.Attachment = None,
     ) -> discord.Thread:
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
             await interaction.response.send_message(
@@ -56,9 +59,20 @@ class GitHubCog(commands.Cog):
         try:
             script_content = (await script.read()).decode("utf-8")
             selected_gpu = GPUType.AMD if gpu_type.value == "amd" else GPUType.NVIDIA
-            run_id = await self.trigger_github_action(
-                script_content, script.filename, selected_gpu
-            )
+
+            if use_leaderboard_eval:
+                reference_content = (await reference_script.read()).decode("utf-8")
+                # eval_code = py_eval if script.filename.endswith(".py") else cu_eval
+                run_id = await self.trigger_github_action(
+                    script_content,
+                    script.filename,
+                    selected_gpu,
+                    reference_content,
+                )
+            else:
+                run_id = await self.trigger_github_action(
+                    script_content, script.filename, selected_gpu
+                )
 
             if run_id:
                 await thread.send(
@@ -87,7 +101,13 @@ class GitHubCog(commands.Cog):
         finally:
             return thread
 
-    async def trigger_github_action(self, script_content, filename, gpu_type):
+    async def trigger_github_action(
+        self,
+        script_content,
+        filename,
+        gpu_type,
+        reference_content=None,
+    ):
         logger.info(f"Attempting to trigger GitHub action for {gpu_type.name} GPU")
         gh = Github(GITHUB_TOKEN)
         repo = gh.get_repo(GITHUB_REPO)
@@ -97,10 +117,23 @@ class GitHubCog(commands.Cog):
             workflow_file = gpu_type.value
             workflow = repo.get_workflow(workflow_file)
 
-            success = workflow.create_dispatch(
-                get_github_branch_name(),
-                {"script_content": script_content, "filename": filename},
-            )
+            if reference_content is None:
+                # eval_filename = "eval.py" if filename.endswith(".py") else "eval.cu"
+                reference_filename = "ref.py" if filename.endswith(".py") else "ref.cu"
+                success = workflow.create_dispatch(
+                    get_github_branch_name(),
+                    {
+                        "script_content": script_content,
+                        "filename": filename,
+                        "reference_content": reference_content,
+                        "reference_filename": reference_filename,
+                    },
+                )
+            else:
+                success = workflow.create_dispatch(
+                    get_github_branch_name(),
+                    {"script_content": script_content, "filename": filename},
+                )
 
             if success:
                 await asyncio.sleep(2)
@@ -138,9 +171,15 @@ class GitHubCog(commands.Cog):
                             logger.warning(f"Failed to cancel workflow run {run_id}")
                     except Exception as e:
                         logger.error(f"Error cancelling workflow: {str(e)}")
-                    
-                    await thread.send(f"Workflow cancelled - exceeded {timeout_minutes} minute timeout")
-                    return "cancelled", f"Workflow exceeded {timeout_minutes} minute timeout", run.html_url
+
+                    await thread.send(
+                        f"Workflow cancelled - exceeded {timeout_minutes} minute timeout"
+                    )
+                    return (
+                        "cancelled",
+                        f"Workflow exceeded {timeout_minutes} minute timeout",
+                        run.html_url,
+                    )
 
                 if run.status == "completed":
                     logs = await self.download_artifact(run_id)

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -8,13 +8,14 @@ from consts import GitHubGPU, ModalGPU
 
 import random
 
-if TYPE_CHECKING:
-    from bot import ClusterBot
-
 
 class LeaderboardSubmitCog(app_commands.Group):
-    def __init__(self, bot):
-        self.bot: ClusterBot = bot
+    def __init__(
+        self,
+        bot: commands.Bot,
+    ):
+        self.bot: commands.Bot = bot
+
         super().__init__(name="submit", description="Submit leaderboard data")
 
     # Parent command that defines global options
@@ -45,7 +46,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             app_commands.Choice(name=gpu.value, value=gpu.value) for gpu in ModalGPU
         ]
     )
-    async def modal(
+    async def submit_modal(
         self,
         interaction: discord.Interaction,
         leaderboard_name: str,
@@ -57,6 +58,15 @@ class LeaderboardSubmitCog(app_commands.Group):
         try:
             # Read the template file
             submission_content = await script.read()
+
+            # Call Modal runner
+            modal_cog = self.bot.get_cog("ModalCog")
+
+            if not all([modal_cog]):
+                await interaction.response.send_message("❌ Required cogs not found!")
+                return
+
+            modal_command = modal_cog.run_modal
 
             # Compute eval or submission score, call runner here.
             score = random.random()
@@ -93,7 +103,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             app_commands.Choice(name=gpu.value, value=gpu.value) for gpu in GitHubGPU
         ]
     )
-    async def github(
+    async def submit_github(
         self,
         interaction: discord.Interaction,
         leaderboard_name: str,
@@ -105,6 +115,15 @@ class LeaderboardSubmitCog(app_commands.Group):
         try:
             # Read the template file
             submission_content = await script.read()
+
+            # Call GH runner
+            github_cog = self.bot.get_cog("GitHubCog")
+
+            if not all([github_cog]):
+                await interaction.response.send_message("❌ Required cogs not found!")
+                return
+
+            github_command = github_cog.run_github
 
             # Compute eval or submission score, call runner here.
             score = random.random()
@@ -132,7 +151,7 @@ class LeaderboardSubmitCog(app_commands.Group):
 
 class LeaderboardCog(commands.Cog):
     def __init__(self, bot):
-        self.bot: ClusterBot = bot
+        self.bot: commands.Bot = bot
         self.get_leaderboards = bot.leaderboard_group.command(name="get")(
             self.get_leaderboards
         )

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from typing import TYPE_CHECKING
 from consts import GitHubGPU, ModalGPU
-from utils import extract_score
+from utils import extract_score, get_user_from_id
 
 import random
 
@@ -171,9 +171,10 @@ class LeaderboardSubmitCog(app_commands.Group):
                     "submission_score": score,
                 })
 
+            user_id = get_user_from_id(interaction.user.id, interaction, self.bot)
             await interaction.followup.send(
                 f""""Ran on GH. Leaderboard '{leaderboard_name}'. 
-                Submission title: {script.filename}. Submission user: {interaction.user.id}. 
+                Submission title: {script.filename}. Submission user: {user_id}. 
                 Runtime: {score} ms""",
             )
         except ValueError:
@@ -301,8 +302,9 @@ class LeaderboardCog(commands.Cog):
         )
 
         for submission in submissions:
+            user_id = get_user_from_id(submission["user_id"], interaction, self.bot)
             embed.add_field(
-                name=f"{submission['user_id']}: {submission['submission_name']}",
+                name=f"{user_id}: {submission['submission_name']}",
                 value=f"Submission speed: {submission['submission_score']}",
                 inline=False,
             )

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -25,7 +25,8 @@ class SchedulerType(Enum):
 
 
 class GitHubGPU(Enum):
-    T4 = "T4"
+    NVIDIA = "nvidia"
+    AMD = "amd"
 
 
 class ModalGPU(Enum):

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -141,6 +141,20 @@ class LeaderboardDB:
             for lb in self.cursor.fetchall()
         ]
 
+    def get_leaderboard(self, leaderboard_name: str) -> int | None:
+        self.cursor.execute(
+            "SELECT * FROM leaderboard WHERE name = %s", (leaderboard_name,)
+        )
+
+        res = self.cursor.fetchone()
+
+        if res:
+            return LeaderboardItem(
+                id=res[0], name=res[1], deadline=res[2], reference_code=res[3]
+            )
+        else:
+            return None
+
     def get_leaderboard_submissions(
         self, leaderboard_name: str
     ) -> list[SubmissionItem]:
@@ -163,13 +177,6 @@ class LeaderboardDB:
             )
             for submission in self.cursor.fetchall()
         ]
-
-    def get_leaderboard_id(self, leaderboard_name: str) -> int | None:
-        self.cursor.execute("SELECT * FROM leaderboard", (leaderboard_name,))
-
-        res = self.cursor.fetchone()
-
-        return res[0] if res else None
 
 
 if __name__ == "__main__":

--- a/src/discord-cluster-manager/leaderboard_eval.py
+++ b/src/discord-cluster-manager/leaderboard_eval.py
@@ -6,7 +6,8 @@ py_eval = """
 from reference import metric
 
 def main():
-    metric()
+    s = metric()
+    print(f'score:{s}')
 
 if __name__ == '__main__':
     main()

--- a/src/discord-cluster-manager/leaderboard_eval.py
+++ b/src/discord-cluster-manager/leaderboard_eval.py
@@ -1,0 +1,18 @@
+########
+# Evaluation scripts to run for leaderboard results
+########
+
+py_eval = """
+from reference import metric
+
+def main():
+    metric()
+
+if __name__ == '__main__':
+    main()
+
+"""
+
+cu_eval = """
+
+"""

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 import datetime
+import re
 from typing import TypedDict
 
 
@@ -35,6 +36,36 @@ def get_github_branch_name():
         return result.stdout.strip().split("/", 1)[1]
     except subprocess.CalledProcessError:
         return "main"
+
+
+def get_user_from_id(id, interaction, bot):
+    if interaction.guild:
+        # In a guild, try to get the member by ID
+        member = interaction.guild.get_member(id)
+        if member:
+            username = member.name
+            return username
+        else:
+            return id
+    else:
+        # If the interaction is in DMs, we can get the user directly
+        user = bot.get_user(id)
+        if user:
+            username = user.name
+            return username
+        else:
+            return id
+
+
+def extract_score(score_str: str) -> float:
+    """
+    Extract score from output logs and push to DB (kind of hacky).
+    """
+    match = re.search(r"score:\s*(-?\d+\.\d+)", score_str)
+    if match:
+        return float(match.group(1))
+    else:
+        return None
 
 
 class LeaderboardItem(TypedDict):

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -39,6 +39,7 @@ def get_github_branch_name():
 
 
 def get_user_from_id(id, interaction, bot):
+    # This currently doesn't work.
     if interaction.guild:
         # In a guild, try to get the member by ID
         member = interaction.guild.get_member(id)


### PR DESCRIPTION
## Description

Enable the creation of leaderboards with a reference script. Currently, the creator has control over all aspects of the script, and only must define a function `def metric() -> float` that returns a score (e.g. wall-clock time). The current flow is

1. Create a leaderboard, e.g. `/leaderboard create {kernel_name} {deadline} {reference.py}
2. Submit a train script with a pre-defined name. This is based on what reference.py expects. e.g. `/leaderboard submit {github/modal} {GPU_TYPE} {script.py}. Wait until the runners are done (takes ~1-2 min atm).
3. See your placement. `/leaderboard show {kernel_name}

The way we grab the score / speed from the eval script and save to the DB is really hacky. I basically look at the saved logs and look for a specific parsable string. We definitely want to update this in the future to be more secure.

## Future TODOs:
- [ ] Be able to sort leaderboard by ascending or descending and name the score. We can either pre-define metrics (e.g. Wall-clock speeds, memory usage, etc.) or have the leaderboard creator do it.
- [ ] Render / write out all users as either a pre-defined name, @S1ro1 I tried using the guild and members APIs but they all don't work for me.
- [ ] Port everything done for GH runners to Modal (relatively easy)
- [ ] Leaderboards should be GPU specific. Right now any GPU can be submitted to the same leaderboard, this needs to be different.
- [ ] Do edge case testing and make sure we don't have faulty DB writes.
- [ ] Fix how score metric is parsed. Currently it's just stdout and parsed from within the Discord handler by looking for a `score: {float}` string. We ideally want this to not be hackable.

# Examples:
![image](https://github.com/user-attachments/assets/c874afb6-8beb-4219-9574-105e9b256821)

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the smoke test on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start a training run by with the slash command `/run`.
    You may need to exercise some judgement about the script and GPU type.
  - Wait for the training run to complete.
  - Copy the URL for the thread started by the cluster bot in response to
    your `/run` message ("Cluster Bot started a thread: ..."):
      - Click on the 3 dots (`...`) to the cluster bot's message.
      - Select *Copy Message Link*.
  - Using the copied URL, run the smoke test:
    ```bash
    python discord-bot-smoke-test.py copied_url
    ```
  - Verify that the smoke test script responds with:
    ```
    All tests passed!
    ```
  For more information on running a cluster bot on your own server, see
  README.md.
