### PR TITLE
Grab and show user names and nicks instead of User IDs

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -29,6 +29,7 @@ logger = setup_logging()
 class ClusterBot(commands.Bot):
     def __init__(self, debug_mode=False):
         intents = discord.Intents.default()
+        intents.members = True
         intents.message_content = True
         super().__init__(intents=intents, command_prefix="!")
         self.debug_mode = debug_mode

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -171,11 +171,13 @@ class LeaderboardSubmitCog(app_commands.Group):
                     "submission_score": score,
                 })
 
-            user_id = get_user_from_id(interaction.user.id, interaction, self.bot)
+            user_id = interaction.user.name
             await interaction.followup.send(
-                f""""Ran on GH. Leaderboard '{leaderboard_name}'. 
-                Submission title: {script.filename}. Submission user: {user_id}. 
-                Runtime: {score} ms""",
+                "Successfully ran on GitHub runners!\n"
+                + f"Leaderboard '{leaderboard_name}'.\n"
+                + f"Submission title: {script.filename}.\n"
+                + f"Submission user: {user_id}\n"
+                + f"Runtime: {score} ms\n",
             )
         except ValueError:
             await interaction.response.send_message(
@@ -193,10 +195,6 @@ class LeaderboardCog(commands.Cog):
         self.leaderboard_create = bot.leaderboard_group.command(
             name="create", description="Create a new leaderboard"
         )(self.leaderboard_create)
-
-        # self.leaderboard_submit = bot.leaderboard_group.command(
-        #     name="submit", description="Submit a file to the leaderboard"
-        # )(self.leaderboard_submit)
 
         bot.leaderboard_group.add_command(LeaderboardSubmitCog(bot))
 
@@ -298,11 +296,17 @@ class LeaderboardCog(commands.Cog):
 
         # Create embed
         embed = discord.Embed(
-            title="Leaderboard Submissions", color=discord.Color.blue()
+            title=f'Leaderboard Submissions for "{leaderboard_name}"',
+            color=discord.Color.blue(),
         )
 
         for submission in submissions:
-            user_id = get_user_from_id(submission["user_id"], interaction, self.bot)
+            user_id = await get_user_from_id(
+                submission["user_id"], interaction, self.bot
+            )
+            print("members", interaction.guild.members)
+            print(user_id)
+
             embed.add_field(
                 name=f"{user_id}: {submission['submission_name']}",
                 value=f"Submission speed: {submission['submission_score']}",

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -8,6 +8,7 @@ from consts import (
     POSTGRES_HOST,
     POSTGRES_PORT,
     POSTGRES_DATABASE,
+    DATABASE_URL,
 )
 
 
@@ -29,7 +30,11 @@ class LeaderboardDB:
     def connect(self) -> bool:
         """Establish connection to the database"""
         try:
-            self.connection = psycopg2.connect(**self.connection_params)
+            self.connection = (
+                psycopg2.connect(DATABASE_URL, sslmode="require")
+                if DATABASE_URL
+                else psycopg2.connect(**self.connection_params)
+            )
             self.cursor = self.connection.cursor()
             self._create_tables()
             return True

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -38,21 +38,21 @@ def get_github_branch_name():
         return "main"
 
 
-def get_user_from_id(id, interaction, bot):
+async def get_user_from_id(id, interaction, bot):
     # This currently doesn't work.
     if interaction.guild:
         # In a guild, try to get the member by ID
-        member = interaction.guild.get_member(id)
+        member = await interaction.guild.fetch_member(id)
         if member:
-            username = member.name
+            username = member.global_name if member.nick is None else member.nick
             return username
         else:
             return id
     else:
         # If the interaction is in DMs, we can get the user directly
-        user = bot.get_user(id)
+        user = await bot.fetch_user(id)
         if user:
-            username = user.name
+            username = user.global_name if member.nick is None else member.nick
             return username
         else:
             return id


### PR DESCRIPTION
## Description

Note, this change requires the bot to have `Server Members Intent` turned on.

The previous leaderboard doesn't show usernames -- it instead shows the user ID numbers, which are not useful. We instead now just grab the user names / nicks (nicks take precedence) using the user IDs. Note that the DB is unchanged and still uses user IDs as keys.

![image](https://github.com/user-attachments/assets/4979b80e-447d-446a-908c-a76f6e0a6566)

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the smoke test on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start a training run by with the slash command `/run`.
    You may need to exercise some judgement about the script and GPU type.
  - Wait for the training run to complete.
  - Copy the URL for the thread started by the cluster bot in response to
    your `/run` message ("Cluster Bot started a thread: ..."):
      - Click on the 3 dots (`...`) to the cluster bot's message.
      - Select *Copy Message Link*.
  - Using the copied URL, run the smoke test:
    ```bash
    python discord-bot-smoke-test.py copied_url
    ```
  - Verify that the smoke test script responds with:
    ```
    All tests passed!
    ```
  For more information on running a cluster bot on your own server, see
  README.md.
