### PR TITLE
use tables in leaderboard schema

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -123,6 +123,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             # Read and convert reference code
             reference_code = None
             with self.bot.leaderboard_db as db:
+                # TODO: query that gets reference code given leaderboard name
                 leaderboard_item = db.get_leaderboard(leaderboard_name)
                 if not leaderboard_item:
                     await interaction.response.send_message(
@@ -278,6 +279,7 @@ class LeaderboardCog(commands.Cog):
         dtype: app_commands.Choice[str] = "fp32",
     ):
         with self.bot.leaderboard_db as db:
+            # TODO: query that gets leaderboard id given leaderboard name
             leaderboard_id = db.get_leaderboard(leaderboard_name)["id"]
             if not leaderboard_id:
                 await interaction.response.send_message(


### PR DESCRIPTION
## Description

This change switches the leaderboard cog to using the tables in the leaderboard schema that were created by the initial migration.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
