### PR TITLE
switch to interaction.followup.send in some places in leaderboard cog

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -126,7 +126,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 # TODO: query that gets reference code given leaderboard name
                 leaderboard_item = db.get_leaderboard(leaderboard_name)
                 if not leaderboard_item:
-                    await interaction.response.send_message(
+                    await interaction.followup.send(
                         f"Leaderboard {leaderboard_name} not found.", ephemeral=True
                     )
                     return
@@ -136,7 +136,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             github_cog = self.bot.get_cog("GitHubCog")
 
             if not all([github_cog]):
-                await interaction.response.send_message("❌ Required cogs not found!")
+                await interaction.followup.send("❌ Required cogs not found!")
                 return
 
             github_command = github_cog.run_github
@@ -181,7 +181,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 + f"Runtime: {score} ms\n",
             )
         except ValueError:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
                 ephemeral=True,
             )


### PR DESCRIPTION
## Description

Calling `/leaderboard submit github` with an unknown leaderboard name results in a traceback and no response on the Discord channel.

```
024-12-12 17:48:37 ERROR    discord.app_commands.tree Ignoring exception in command 'github'
Traceback (most recent call last):
  File "/home/.../Code/Discord-cluster-manager/.venv/lib/python3.13/site-packages/discord/app_commands/commands.py", line 857, in _do_call
    return await self._callback(self.binding, interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.../Code/Discord-cluster-manager/src/discord-cluster-manager/cogs/leaderboard_cog.py", line 129, in submit_github
    await interaction.response.send_message(
        f"Leaderboard {leaderboard_name} not found.", ephemeral=True
    )
  File "/home/.../Code/Discord-cluster-manager/.venv/lib/python3.13/site-packages/discord/interactions.py", line 827, in send_message
    raise InteractionResponded(self._parent)
discord.errors.InteractionResponded: This interaction has already been responded to before

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/.../Code/Discord-cluster-manager/.venv/lib/python3.13/site-packages/discord/app_commands/tree.py", line 1310, in _call
    await command._invoke_with_namespace(interaction, namespace)
  File "/home/.../Code/Discord-cluster-manager/.venv/lib/python3.13/site-packages/discord/app_commands/commands.py", line 883, in _invoke_with_namespace
    return await self._do_call(interaction, transformed_values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.../Code/Discord-cluster-manager/.venv/lib/python3.13/site-packages/discord/app_commands/commands.py", line 876, in _do_call
    raise CommandInvokeError(self, e) from e
discord.app_commands.errors.CommandInvokeError: Command 'github' raised an exception: InteractionResponded: This interaction has already been responded to before
```

The bot does stay up (I said in #dev-notes that it does not, but I was wrong).

![image](https://github.com/user-attachments/assets/244ababc-a40d-4a8c-8899-92b32ad2866a)

## Checklist

I haven't checked the GitHub runner, as there is currently a problem with it. But the Modal runner is working in my local.

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
