### PR TITLE
QoL changes: Add GPU types view, remove dtype and shapes info. No DB or functionality.

### DIFF
--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -99,7 +99,7 @@ class LeaderboardDB:
         """Context manager exit"""
         self.disconnect()
 
-    def create_leaderboard(self, leaderboard: LeaderboardItem):
+    def create_leaderboard(self, leaderboard: LeaderboardItem) -> Optional[str]:
         try:
             self.cursor.execute(
                 """
@@ -114,8 +114,10 @@ class LeaderboardDB:
             )
             self.connection.commit()
         except psycopg2.Error as e:
-            print(f"Error during leaderboard creation: {e}")
             self.connection.rollback()  # Ensure rollback if error occurs
+            return f"Error during leaderboard creation: {e}"
+
+        return None
 
     def create_submission(self, submission: SubmissionItem):
         try:
@@ -139,7 +141,9 @@ class LeaderboardDB:
             self.connection.rollback()  # Ensure rollback if error occurs
 
     def get_leaderboards(self) -> list[LeaderboardItem]:
-        self.cursor.execute("SELECT id, name, deadline, reference_code FROM leaderboard.problem")
+        self.cursor.execute(
+            "SELECT id, name, deadline, reference_code FROM leaderboard.problem"
+        )
 
         return [
             LeaderboardItem(id=lb[0], name=lb[1], deadline=lb[2], reference_code=lb[3])
@@ -149,7 +153,7 @@ class LeaderboardDB:
     def get_leaderboard(self, leaderboard_name: str) -> int | None:
         self.cursor.execute(
             "SELECT id, name, deadline, reference_code FROM leaderboard.problem WHERE name = %s",
-            (leaderboard_name,)
+            (leaderboard_name,),
         )
 
         res = self.cursor.fetchone()

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 import datetime
 import re
-from typing import TypedDict
+from typing import TypedDict, List
 
 
 def setup_logging():
@@ -73,6 +73,7 @@ class LeaderboardItem(TypedDict):
     name: str
     deadline: datetime.datetime
     reference_code: str
+    gpu_types: List[str]
 
 
 class SubmissionItem(TypedDict):


### PR DESCRIPTION
A bunch of quality of life changes, as well as a change to GPU types.

Adds:
* Checkers and ephemeral info when leaderboard creation is invalid (duplicate key, invalid dates, etc.) in try-catch.
* New option and view to select GPU during problem creation.
![image](https://github.com/user-attachments/assets/fc14103e-903a-4970-b750-5553cea995e3)


Removes:
* `dtype` and `shape` information in `/leaderboard submit ...`.
* `dtype` and `shape` information in `/leaderboard create ...`.

Leftover TODOs:
* [ ] (urgent ⚠️!) Add DB changes to reflect new GPUs. @b9r5 let's talk about this more, but I think we should just have either score point to a DB with each valid GPU type (eh), or add a score for each possible GPU in the DB.
* [ ] Add leaderboard delete (dangerous! we should also have special UI for this so users are sure)
* [ ] Update `/leaderboard list` to also include all available GPU types for the particular problem.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
