### PR TITLE
drop old leaderboard tables

### DIFF
--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -36,7 +36,6 @@ class LeaderboardDB:
                 else psycopg2.connect(**self.connection_params)
             )
             self.cursor = self.connection.cursor()
-            self._create_tables()
             return True
         except Error as e:
             print(f"Error connecting to PostgreSQL: {e}")
@@ -48,47 +47,6 @@ class LeaderboardDB:
             self.cursor.close()
         if self.connection:
             self.connection.close()
-
-    def _create_tables(self):
-        """Create necessary tables if they don't exist"""
-        create_table_query = """
-        CREATE TABLE IF NOT EXISTS leaderboard (
-            id SERIAL PRIMARY KEY,
-            name TEXT UNIQUE NOT NULL,
-            deadline TIMESTAMP NOT NULL,
-            reference_code TEXT NOT NULL
-        );
-        """
-
-        create_submission_table_query = """
-        CREATE TABLE IF NOT EXISTS submissions (
-            submission_id SERIAL PRIMARY KEY,
-            leaderboard_id TEXT NOT NULL,
-            submission_name VARCHAR(255) NOT NULL,
-            user_id TEXT NOT NULL,
-            code TEXT NOT NULL,
-            submission_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            submission_score DOUBLE PRECISION NOT NULL,
-            FOREIGN KEY (leaderboard_id) REFERENCES leaderboard(name)
-        );
-        """
-
-        create_run_information_table_query = """
-        CREATE TABLE IF NOT EXISTS runinfo (
-            submission_id INTEGER NOT NULL,
-            stdout TEXT,
-            ncu_output TEXT,
-            FOREIGN KEY (submission_id) REFERENCES submissions(submission_id)
-        );
-        """
-
-        try:
-            self.cursor.execute(create_table_query)
-            self.cursor.execute(create_submission_table_query)
-            self.cursor.execute(create_run_information_table_query)
-            self.connection.commit()
-        except Error as e:
-            print(f"Error creating table: {e}")
 
     def __enter__(self):
         """Context manager entry"""

--- a/src/discord-cluster-manager/migrations/20241214_01_M62BX-drop-old-leaderboard-tables.py
+++ b/src/discord-cluster-manager/migrations/20241214_01_M62BX-drop-old-leaderboard-tables.py
@@ -1,0 +1,17 @@
+"""
+This migration drops tables in the public schema that we were previously
+creating. The leaderboard tables are now in the leaderboard schema, so we dont'
+need the tables in the public schema any more. I think the CASCADE clauses will
+cause the sequences owned by the old tables to be dropped, but if not we'll need
+another migration.
+"""
+
+from yoyo import step
+
+__depends__ = {'20241208_01_p3yuR-initial-leaderboard-schema'}
+
+steps = [
+    step("DROP TABLE IF EXISTS public.leaderboard CASCADE"),
+    step("DROP TABLE IF EXISTS public.submissions CASCADE"),
+    step("DROP TABLE IF EXISTS public.runinfo CASCADE")
+]


### PR DESCRIPTION
## Description

This PR drops leaderboard tables in the public schema that we're no longer using.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

I kind of did the following: I ran Modal and GitHub runs and visually inspected their output. `\verifyruns` is still broken because it does not have `score:` lines in the output.

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
