### PR TITLE
Remove "score regex" to fix /verifyruns

### DIFF
--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -92,15 +92,6 @@ jobs:
           cat training.log  # Debug: show output
         fi
 
-    - name: Extract score
-      shell: bash
-      run: |
-        # Extract only the last occurrence of "score:"
-        score=$(grep -oP 'score:\s*\d+(\.\d+)?' training.log | tail -n 1 | awk '{print $2}')
-
-        echo "Score extracted: $score"
-        echo "::set-output name=score::$score"
-
     - name: Upload training artifacts
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -120,15 +120,6 @@ jobs:
             cat training.log  # Debug: show output
           fi
 
-      - name: Extract score
-        shell: bash
-        run: |
-          # Extract only the last occurrence of "score:"
-          score=$(grep -oP 'score:\s*\d+(\.\d+)?' training.log | tail -n 1 | awk '{print $2}')
-
-          echo "Score extracted: $score"
-          echo "::set-output name=score::$score"
-
       - name: Upload training artifacts
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Description

Remove the scores step in the NVIDIA and AMD job submission workflows.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
