### PR TITLE
Change: /leaderboard get --> /leaderboard list

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -226,7 +226,7 @@ class GPUSelectionView(ui.View):
 class LeaderboardCog(commands.Cog):
     def __init__(self, bot):
         self.bot: commands.Bot = bot
-        self.get_leaderboards = bot.leaderboard_group.command(name="get")(
+        self.get_leaderboards = bot.leaderboard_group.command(name="list")(
             self.get_leaderboards
         )
         self.leaderboard_create = bot.leaderboard_group.command(


### PR DESCRIPTION
## Description

A one-line change to change `/leaderboard get` to `/leaderboard list`, which makes a lot more sense for listing available leaderboards.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
