### PR TITLE
Replace all relevant Interaction.send/followups with send_discord_message wrapper

### DIFF
--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -10,7 +10,7 @@ from discord import app_commands
 from discord.ext import commands
 from github import Github
 from leaderboard_eval import cu_eval, py_eval
-from utils import get_github_branch_name, setup_logging, send_discord_message
+from utils import get_github_branch_name, send_discord_message, setup_logging
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -10,7 +10,7 @@ from discord import app_commands
 from discord.ext import commands
 from github import Github
 from leaderboard_eval import cu_eval, py_eval
-from utils import get_github_branch_name, setup_logging
+from utils import get_github_branch_name, setup_logging, send_discord_message
 
 logger = setup_logging()
 
@@ -37,24 +37,19 @@ class GitHubCog(commands.Cog):
         interaction: discord.Interaction,
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
-        use_followup: bool = False,
         reference_script: discord.Attachment = None,
         reference_code: str = None,
     ) -> discord.Thread:
         if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
-            await interaction.response.send_message(
-                "Please provide a Python (.py) or CUDA (.cu) file"
+            await send_discord_message(
+                interaction, "Please provide a Python (.py) or CUDA (.cu) file"
             )
             return None
 
         thread = await self.bot.create_thread(interaction, gpu_type.name, "GitHub Job")
         message = f"Created thread {thread.mention} for your GitHub job"
 
-        if use_followup:
-            await interaction.followup.send(message)
-        else:
-            await interaction.response.send_message(message)
-
+        await send_discord_message(interaction, message)
         await thread.send(f"Processing `{script.filename}` with {gpu_type.name}...")
 
         try:

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -5,7 +5,7 @@ import discord
 from consts import GitHubGPU, ModalGPU
 from discord import Interaction, SelectOption, app_commands, ui
 from discord.ext import commands
-from utils import extract_score, get_user_from_id, setup_logging
+from utils import extract_score, get_user_from_id, setup_logging, send_discord_message
 
 logger = setup_logging()
 
@@ -148,7 +148,6 @@ class LeaderboardSubmitCog(app_commands.Group):
                     script,
                     gpu_type,
                     reference_code=reference_code,
-                    use_followup=True,
                 )
             except discord.errors.NotFound as e:
                 print(f"Webhook not found: {e}")
@@ -284,18 +283,12 @@ class LeaderboardCog(commands.Cog):
         # Ask the user to select GPUs
         view = GPUSelectionView([gpu.name for gpu in GitHubGPU])
 
-        if interaction.response.is_done():
-            await interaction.followup.send(
-                "Please select GPUs for this leaderboard.",
-                view=view,
-                ephemeral=True,
-            )
-        else:
-            await interaction.response.send_message(
-                "Please select GPUs for this leaderboard.",
-                view=view,
-                ephemeral=True,
-            )
+        await send_discord_message(
+            interaction,
+            "Please select GPUs for this leaderboard.",
+            view=view,
+            ephemeral=True,
+        )
 
         await view.wait()
 
@@ -311,7 +304,6 @@ class LeaderboardCog(commands.Cog):
                     "gpu_types": view.selected_gpus,
                 })
 
-                print("HAHA", err)
                 if err:
                     if "duplicate key" in err:
                         await interaction.followup.send(

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -58,7 +58,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             modal_cog = self.bot.get_cog("ModalCog")
 
             if not all([modal_cog]):
-                await interaction.response.send_message("❌ Required cogs not found!")
+                await send_discord_message(interaction, "❌ Required cogs not found!")
                 return
 
             # Compute eval or submission score, call runner here.
@@ -74,7 +74,8 @@ class LeaderboardSubmitCog(app_commands.Group):
                     "submission_score": score,
                 })
 
-            await interaction.response.send_message(
+            await send_discord_message(
+                interaction,
                 f"Ran on Modal. Leaderboard '{leaderboard_name}'.\n"
                 + f"Submission title: {script.filename}.\n"
                 + f"Submission user: {interaction.user.id}.\n"
@@ -82,7 +83,8 @@ class LeaderboardSubmitCog(app_commands.Group):
                 ephemeral=True,
             )
         except ValueError:
-            await interaction.response.send_message(
+            await send_discord_message(
+                interaction,
                 "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
                 ephemeral=True,
             )
@@ -112,8 +114,8 @@ class LeaderboardSubmitCog(app_commands.Group):
         try:
             submission_content = submission_content.decode()
         except UnicodeError:
-            await interaction.response.send_message(
-                "Could not decode your file. Is it UTF-8?", ephemeral=True
+            await send_discord_message(
+                interaction, "Could not decode your file. Is it UTF-8?", ephemeral=True
             )
             return
 
@@ -139,7 +141,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             github_cog = self.bot.get_cog("GitHubCog")
 
             if not all([github_cog]):
-                await interaction.followup.send("❌ Required cogs not found!")
+                await send_discord_message(interaction, "❌ Required cogs not found!")
                 return
 
             github_command = github_cog.run_github
@@ -153,7 +155,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 )
             except discord.errors.NotFound as e:
                 print(f"Webhook not found: {e}")
-                await interaction.followup.send("❌ The webhook was not found.")
+                await send_discord_message(interaction, "❌ The webhook was not found.")
 
             message_contents = [
                 msg.content async for msg in github_thread.history(limit=None)
@@ -356,16 +358,20 @@ class LeaderboardCog(commands.Cog):
                 # TODO: query that gets leaderboard id given leaderboard name
                 leaderboard_id = db.get_leaderboard(leaderboard_name)["id"]
                 if not leaderboard_id:
-                    await interaction.response.send_message(
-                        f'Leaderboard "{leaderboard_name}" not found.', ephemeral=True
+                    await send_discord_message(
+                        interaction,
+                        f'Leaderboard "{leaderboard_name}" not found.',
+                        ephemeral=True,
                     )
                     return
 
                 submissions = db.get_leaderboard_submissions(leaderboard_name)
 
             if not submissions:
-                await interaction.response.send_message(
-                    f'No submissions found for "{leaderboard_name}".', ephemeral=True
+                await send_discord_message(
+                    interaction,
+                    f'No submissions found for "{leaderboard_name}".',
+                    ephemeral=True,
                 )
                 return
 
@@ -390,11 +396,12 @@ class LeaderboardCog(commands.Cog):
         except Exception as e:
             logger.error(str(e))
             if "'NoneType' object is not subscriptable" in str(e):
-                await interaction.response.send_message(
+                await send_discord_message(
+                    interaction,
                     f"The leaderboard '{leaderboard_name}' doesn't exist.",
                     ephemeral=True,
                 )
             else:
-                await interaction.response.send_message(
-                    "An unknown error occurred.", ephemeral=True
+                await send_discord_message(
+                    interaction, "An unknown error occurred.", ephemeral=True
                 )

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -124,8 +124,10 @@ class LeaderboardSubmitCog(app_commands.Group):
                 # TODO: query that gets reference code given leaderboard name
                 leaderboard_item = db.get_leaderboard(leaderboard_name)
                 if not leaderboard_item:
-                    await interaction.response.send_message(
-                        f"Leaderboard {leaderboard_name} not found.", ephemeral=True
+                    await send_discord_message(
+                        interaction,
+                        f"Leaderboard {leaderboard_name} not found.",
+                        ephemeral=True,
                     )
                     return
                 reference_code = leaderboard_item["reference_code"]
@@ -176,7 +178,8 @@ class LeaderboardSubmitCog(app_commands.Group):
                 if interaction.user.nick is None
                 else interaction.user.nick
             )
-            await interaction.followup.send(
+            await send_discord_message(
+                interaction,
                 "Successfully ran on GitHub runners!\n"
                 + f"Leaderboard '{leaderboard_name}'.\n"
                 + f"Submission title: {script.filename}.\n"
@@ -184,7 +187,8 @@ class LeaderboardSubmitCog(app_commands.Group):
                 + f"Runtime: {score} ms\n",
             )
         except ValueError:
-            await interaction.followup.send(
+            await send_discord_message(
+                interaction,
                 "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
                 ephemeral=True,
             )
@@ -208,7 +212,8 @@ class GPUSelectionView(ui.View):
         # Retrieve the selected options
         select = interaction.data["values"]
         self.selected_gpus = select
-        await interaction.response.send_message(
+        await send_discord_message(
+            interaction,
             f"Selected GPUs: {', '.join(self.selected_gpus)}",
             ephemeral=True,
         )
@@ -239,7 +244,9 @@ class LeaderboardCog(commands.Cog):
             leaderboards = db.get_leaderboards()
 
         if not leaderboards:
-            await interaction.followup.send("No leaderboards found.", ephemeral=True)
+            await send_discord_message(
+                interaction, "No leaderboards found.", ephemeral=True
+            )
             return
 
         # Create embed
@@ -252,7 +259,7 @@ class LeaderboardCog(commands.Cog):
                 name=lb["name"], value=f"Deadline: {deadline_str}", inline=False
             )
 
-        await interaction.followup.send(embed=embed)
+        await send_discord_message(interaction, embed=embed)
 
     @discord.app_commands.describe(
         leaderboard_name="Name of the leaderboard",
@@ -274,7 +281,8 @@ class LeaderboardCog(commands.Cog):
                 date_value = datetime.strptime(deadline, "%Y-%m-%d")
             except ValueError as ve:
                 logger.error(f"Value Error: {str(ve)}", exc_info=True)
-                await interaction.response.send_message(
+                await send_discord_message(
+                    interaction,
                     "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
                     ephemeral=True,
                 )
@@ -306,20 +314,23 @@ class LeaderboardCog(commands.Cog):
 
                 if err:
                     if "duplicate key" in err:
-                        await interaction.followup.send(
+                        await send_discord_message(
+                            interaction,
                             f'Error: Tried to create a leaderboard "{leaderboard_name}" that already exists.',
                             ephemeral=True,
                         )
                     else:
                         # Handle any other errors
                         logger.error(f"Error in leaderboard creation: {err}")
-                        await interaction.followup.send(
+                        await send_discord_message(
+                            interaction,
                             "Error in leaderboard creation.",
                             ephemeral=True,
                         )
                     return
 
-            await interaction.followup.send(
+            await send_discord_message(
+                interaction,
                 f"Leaderboard '{leaderboard_name}'.\n"
                 + f"Reference code: {reference_code}. Submission deadline: {date_value}",
                 ephemeral=True,
@@ -328,7 +339,8 @@ class LeaderboardCog(commands.Cog):
         except Exception as e:
             logger.error(f"Error in leaderboard creation: {e}")
             # Handle any other errors
-            await interaction.followup.send(
+            await send_discord_message(
+                interaction,
                 "Error in leaderboard creation.",
                 ephemeral=True,
             )

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -259,7 +259,7 @@ class LeaderboardCog(commands.Cog):
                 name=lb["name"], value=f"Deadline: {deadline_str}", inline=False
             )
 
-        await send_discord_message(interaction, embed=embed)
+        await interaction.followup.send(interaction, embed=embed)
 
     @discord.app_commands.describe(
         leaderboard_name="Name of the leaderboard",

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -328,7 +328,8 @@ class LeaderboardCog(commands.Cog):
                     return
 
             await interaction.followup.send(
-                f"Leaderboard '{leaderboard_name}'. Reference code: {reference_code}. Submission deadline: {date_value}",
+                f"Leaderboard '{leaderboard_name}'.\n"
+                + f"Reference code: {reference_code}. Submission deadline: {date_value}",
                 ephemeral=True,
             )
 

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -2,9 +2,8 @@ import random
 from datetime import datetime
 
 import discord
-from discord import ui, SelectOption, Interaction
 from consts import GitHubGPU, ModalGPU
-from discord import app_commands
+from discord import Interaction, SelectOption, app_commands, ui
 from discord.ext import commands
 from utils import extract_score, get_user_from_id
 

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -5,7 +5,9 @@ import discord
 from consts import GitHubGPU, ModalGPU
 from discord import Interaction, SelectOption, app_commands, ui
 from discord.ext import commands
-from utils import extract_score, get_user_from_id
+from utils import extract_score, get_user_from_id, setup_logging
+
+logger = setup_logging()
 
 
 class LeaderboardSubmitCog(app_commands.Group):
@@ -21,8 +23,6 @@ class LeaderboardSubmitCog(app_commands.Group):
     @app_commands.describe(
         leaderboard_name="Name of the competition / kernel to optimize",
         script="The Python / CUDA script file to run",
-        dtype="dtype (e.g. FP32, BF16, FP4) that the input and output expects.",
-        shape="Data input shape as a tuple",
     )
     # TODO: Modularize this so all the write functionality is in here. Haven't figured
     # a good way to do this yet.
@@ -31,8 +31,6 @@ class LeaderboardSubmitCog(app_commands.Group):
         interaction: discord.Interaction,
         leaderboard_name: str,
         script: discord.Attachment,
-        dtype: app_commands.Choice[str] = None,
-        shape: app_commands.Choice[str] = None,
     ):
         pass
 
@@ -51,8 +49,6 @@ class LeaderboardSubmitCog(app_commands.Group):
         leaderboard_name: str,
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
-        dtype: app_commands.Choice[str] = "fp32",
-        shape: app_commands.Choice[str] = None,
     ):
         try:
             # Read the template file
@@ -109,8 +105,6 @@ class LeaderboardSubmitCog(app_commands.Group):
         leaderboard_name: str,
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
-        dtype: app_commands.Choice[str] = "fp32",
-        shape: app_commands.Choice[str] = None,
     ):
         # Read the template file
         submission_content = await script.read()
@@ -147,7 +141,6 @@ class LeaderboardSubmitCog(app_commands.Group):
                 return
 
             github_command = github_cog.run_github
-            print(github_command)
             try:
                 github_thread = await github_command.callback(
                     github_cog,
@@ -274,64 +267,75 @@ class LeaderboardCog(commands.Cog):
         deadline: str,
         reference_code: discord.Attachment,
     ):
+        # Try parsing with time first
         try:
-            # Try parsing with time first
+            date_value = datetime.strptime(deadline, "%Y-%m-%d %H:%M")
+        except ValueError:
             try:
-                date_value = datetime.strptime(deadline, "%Y-%m-%d %H:%M")
-            except ValueError:
-                # If that fails, try parsing just the date (will set time to 00:00)
                 date_value = datetime.strptime(deadline, "%Y-%m-%d")
+            except ValueError as ve:
+                logger.error(f"Value Error: {str(ve)}", exc_info=True)
+                await interaction.response.send_message(
+                    "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
+                    ephemeral=True,
+                )
+                return
 
+        # Ask the user to select GPUs
+        view = GPUSelectionView([gpu.name for gpu in GitHubGPU])
+
+        if interaction.response.is_done():
+            await interaction.followup.send(
+                "Please select GPUs for this leaderboard.",
+                view=view,
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "Please select GPUs for this leaderboard.",
+                view=view,
+                ephemeral=True,
+            )
+
+        await view.wait()
+
+        try:
             # Read the template file
             template_content = await reference_code.read()
 
-            # Ask the user to select GPUs
-            view = GPUSelectionView([gpu.name for gpu in GitHubGPU])
-
-            if interaction.response.is_done():
-                await interaction.followup.send(
-                    "Please select GPUs for this leaderboard.",
-                    view=view,
-                    ephemeral=True,
-                )
-            else:
-                await interaction.response.send_message(
-                    "Please select GPUs for this leaderboard.",
-                    view=view,
-                    ephemeral=True,
-                )
-
-            await view.wait()
-
             with self.bot.leaderboard_db as db:
-                print(
-                    leaderboard_name,
-                    type(date_value),
-                    type(template_content.decode("utf-8")),
-                )
-                db.create_leaderboard({
+                err = db.create_leaderboard({
                     "name": leaderboard_name,
                     "deadline": date_value,
                     "reference_code": template_content.decode("utf-8"),
+                    "gpu_types": view.selected_gpus,
                 })
 
-            if interaction.response.is_done():
-                await interaction.followup.send(
-                    f"Leaderboard '{leaderboard_name}' created.\n"
-                    + f"Reference code: {reference_code}.\n"
-                    + f"Submission deadline: {date_value}",
-                    ephemeral=True,
-                )
-            else:
-                await interaction.response.send_message(
-                    f"Leaderboard '{leaderboard_name}' created.\n"
-                    + f"Reference code: {reference_code}.\n"
-                    + f"Submission deadline: {date_value}",
-                    ephemeral=True,
-                )
-        except ValueError:
-            await interaction.response.send_message(
-                "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
+                if err:
+                    if "duplicate key" in err:
+                        await interaction.followup.send(
+                            f'Error: Tried to create a leaderboard "{leaderboard_name}" that already exists.',
+                            ephemeral=True,
+                        )
+                    else:
+                        # Handle any other errors
+                        logger.error(f"Error in leaderboard creation: {err}")
+                        await interaction.followup.send(
+                            "Error in leaderboard creation.",
+                            ephemeral=True,
+                        )
+                    return
+
+            await interaction.followup.send(
+                f"Leaderboard '{leaderboard_name}'. Reference code: {reference_code}. Submission deadline: {date_value}",
+                ephemeral=True,
+            )
+
+        except Exception as e:
+            logger.error(f"Error in leaderboard creation: {e}")
+            # Handle any other errors
+            await interaction.followup.send(
+                "Error in leaderboard creation.",
                 ephemeral=True,
             )
 
@@ -340,43 +344,51 @@ class LeaderboardCog(commands.Cog):
         self,
         interaction: discord.Interaction,
         leaderboard_name: str,
-        dtype: app_commands.Choice[str] = "fp32",
     ):
-        with self.bot.leaderboard_db as db:
-            # TODO: query that gets leaderboard id given leaderboard name
-            leaderboard_id = db.get_leaderboard(leaderboard_name)["id"]
-            if not leaderboard_id:
+        try:
+            with self.bot.leaderboard_db as db:
+                # TODO: query that gets leaderboard id given leaderboard name
+                leaderboard_id = db.get_leaderboard(leaderboard_name)["id"]
+                if not leaderboard_id:
+                    await interaction.response.send_message(
+                        f'Leaderboard "{leaderboard_name}" not found.', ephemeral=True
+                    )
+                    return
+
+                submissions = db.get_leaderboard_submissions(leaderboard_name)
+
+            if not submissions:
                 await interaction.response.send_message(
-                    "Leaderboard not found.", ephemeral=True
+                    f'No submissions found for "{leaderboard_name}".', ephemeral=True
                 )
                 return
 
-            # submissions = db.get_leaderboard_submissions(leaderboard_id)  # Add dtype
-            submissions = db.get_leaderboard_submissions(leaderboard_name)  # Add dtype
-
-        if not submissions:
-            await interaction.response.send_message(
-                "No submissions found.", ephemeral=True
-            )
-            return
-
-        # Create embed
-        embed = discord.Embed(
-            title=f'Leaderboard Submissions for "{leaderboard_name}"',
-            color=discord.Color.blue(),
-        )
-
-        for submission in submissions:
-            user_id = await get_user_from_id(
-                submission["user_id"], interaction, self.bot
-            )
-            print("members", interaction.guild.members)
-            print(user_id)
-
-            embed.add_field(
-                name=f"{user_id}: {submission['submission_name']}",
-                value=f"Submission speed: {submission['submission_score']}",
-                inline=False,
+            # Create embed
+            embed = discord.Embed(
+                title=f'Leaderboard Submissions for "{leaderboard_name}"',
+                color=discord.Color.blue(),
             )
 
-        await interaction.response.send_message(embed=embed)
+            for submission in submissions:
+                user_id = await get_user_from_id(
+                    submission["user_id"], interaction, self.bot
+                )
+
+                embed.add_field(
+                    name=f"{user_id}: {submission['submission_name']}",
+                    value=f"Submission speed: {submission['submission_score']}",
+                    inline=False,
+                )
+
+            await interaction.response.send_message(embed=embed)
+        except Exception as e:
+            logger.error(str(e))
+            if "'NoneType' object is not subscriptable" in str(e):
+                await interaction.response.send_message(
+                    f"The leaderboard '{leaderboard_name}' doesn't exist.",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.response.send_message(
+                    "An unknown error occurred.", ephemeral=True
+                )

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -311,6 +311,7 @@ class LeaderboardCog(commands.Cog):
                     "gpu_types": view.selected_gpus,
                 })
 
+                print("HAHA", err)
                 if err:
                     if "duplicate key" in err:
                         await interaction.followup.send(

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -5,7 +5,7 @@ import discord
 from consts import GitHubGPU, ModalGPU
 from discord import Interaction, SelectOption, app_commands, ui
 from discord.ext import commands
-from utils import extract_score, get_user_from_id, setup_logging, send_discord_message
+from utils import extract_score, get_user_from_id, send_discord_message, setup_logging
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -2,6 +2,7 @@ import random
 from datetime import datetime
 
 import discord
+from discord import ui, SelectOption, Interaction
 from consts import GitHubGPU, ModalGPU
 from discord import app_commands
 from discord.ext import commands
@@ -179,7 +180,11 @@ class LeaderboardSubmitCog(app_commands.Group):
                     "submission_score": score,
                 })
 
-            user_id = interaction.user.global_name if interaction.user.nick is None else interaction.user.nick
+            user_id = (
+                interaction.user.global_name
+                if interaction.user.nick is None
+                else interaction.user.nick
+            )
             await interaction.followup.send(
                 "Successfully ran on GitHub runners!\n"
                 + f"Leaderboard '{leaderboard_name}'.\n"
@@ -192,6 +197,31 @@ class LeaderboardSubmitCog(app_commands.Group):
                 "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
                 ephemeral=True,
             )
+
+
+class GPUSelectionView(ui.View):
+    def __init__(self, available_gpus: list[str]):
+        super().__init__()
+
+        # Add the Select Menu with the list of GPU options
+        select = ui.Select(
+            placeholder="Select GPUs for this leaderboard...",
+            options=[SelectOption(label=gpu, value=gpu) for gpu in available_gpus],
+            min_values=1,  # Minimum number of selections
+            max_values=len(available_gpus),  # Maximum number of selections
+        )
+        select.callback = self.select_callback
+        self.add_item(select)
+
+    async def select_callback(self, interaction: Interaction):
+        # Retrieve the selected options
+        select = interaction.data["values"]
+        self.selected_gpus = select
+        await interaction.response.send_message(
+            f"Selected GPUs: {', '.join(self.selected_gpus)}",
+            ephemeral=True,
+        )
+        self.stop()
 
 
 class LeaderboardCog(commands.Cog):
@@ -256,6 +286,24 @@ class LeaderboardCog(commands.Cog):
             # Read the template file
             template_content = await reference_code.read()
 
+            # Ask the user to select GPUs
+            view = GPUSelectionView([gpu.name for gpu in GitHubGPU])
+
+            if interaction.response.is_done():
+                await interaction.followup.send(
+                    "Please select GPUs for this leaderboard.",
+                    view=view,
+                    ephemeral=True,
+                )
+            else:
+                await interaction.response.send_message(
+                    "Please select GPUs for this leaderboard.",
+                    view=view,
+                    ephemeral=True,
+                )
+
+            await view.wait()
+
             with self.bot.leaderboard_db as db:
                 print(
                     leaderboard_name,
@@ -268,12 +316,20 @@ class LeaderboardCog(commands.Cog):
                     "reference_code": template_content.decode("utf-8"),
                 })
 
-            await interaction.response.send_message(
-                f"Leaderboard '{leaderboard_name}' created.\n"
-                + f"Reference code: {reference_code}.\n"
-                + f"Submission deadline: {date_value}",
-                ephemeral=True,
-            )
+            if interaction.response.is_done():
+                await interaction.followup.send(
+                    f"Leaderboard '{leaderboard_name}' created.\n"
+                    + f"Reference code: {reference_code}.\n"
+                    + f"Submission deadline: {date_value}",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.response.send_message(
+                    f"Leaderboard '{leaderboard_name}' created.\n"
+                    + f"Reference code: {reference_code}.\n"
+                    + f"Submission deadline: {date_value}",
+                    ephemeral=True,
+                )
         except ValueError:
             await interaction.response.send_message(
                 "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",

--- a/src/discord-cluster-manager/cogs/misc_cog.py
+++ b/src/discord-cluster-manager/cogs/misc_cog.py
@@ -3,7 +3,7 @@ import psycopg2
 from consts import DATABASE_URL
 from discord import app_commands
 from discord.ext import commands
-from utils import setup_logging
+from utils import setup_logging, send_discord_message
 
 logger = setup_logging()
 
@@ -15,7 +15,7 @@ class BotManagerCog(commands.Cog):
     @app_commands.command(name="ping")
     async def ping(self, interaction: discord.Interaction):
         """Simple ping command to check if the bot is responsive"""
-        await interaction.response.send_message("pong")
+        await send_discord_message(interaction, "pong")
 
     @app_commands.command(name="resync")
     async def resync(self, interaction: discord.Interaction):
@@ -27,16 +27,17 @@ class BotManagerCog(commands.Cog):
                 self.bot.tree.clear_commands(guild=interaction.guild)
                 await self.bot.tree.sync(guild=interaction.guild)
                 commands = await self.bot.tree.fetch_commands(guild=interaction.guild)
-                await interaction.followup.send(
+                send_discord_message(
+                    interaction,
                     "Resynced commands:\n"
-                    + "\n".join([f"- /{cmd.name}" for cmd in commands])
+                    + "\n".join([f"- /{cmd.name}" for cmd in commands]),
                 )
             except Exception as e:
                 logger.error(f"Error in resync command: {str(e)}", exc_info=True)
-                await interaction.followup.send(f"Error: {str(e)}")
+                send_discord_message(interaction, f"Error: {str(e)}")
         else:
-            await interaction.response.send_message(
-                "You need administrator permissions to use this command"
+            await send_discord_message(
+                interaction, "You need administrator permissions to use this command"
             )
 
     @app_commands.command(name="verifydb")
@@ -45,20 +46,22 @@ class BotManagerCog(commands.Cog):
         if not DATABASE_URL:
             message = "DATABASE_URL not set."
             logger.error(message)
-            await interaction.response.send_message(message)
+            await send_discord_message(interaction, message)
             return
 
         try:
-            with psycopg2.connect(DATABASE_URL, sslmode='require') as conn:
+            with psycopg2.connect(DATABASE_URL, sslmode="require") as conn:
                 with conn.cursor() as cursor:
                     cursor.execute("SELECT RANDOM()")
                     result = cursor.fetchone()
                     if result:
                         random_value = result[0]
-                        await interaction.response.send_message(f"Your lucky number is {random_value}.")
+                        await send_discord_message(
+                            interaction, f"Your lucky number is {random_value}."
+                        )
                     else:
-                        await interaction.response.send_message("No result returned.")
+                        await send_discord_message(interaction, "No result returned.")
         except Exception as e:
             message = "Error interacting with the database"
             logger.error(f"{message}: {str(e)}", exc_info=True)
-            await interaction.response.send_message(f"{message}.")
+            await send_discord_message(interaction, f"{message}.")

--- a/src/discord-cluster-manager/cogs/misc_cog.py
+++ b/src/discord-cluster-manager/cogs/misc_cog.py
@@ -3,7 +3,7 @@ import psycopg2
 from consts import DATABASE_URL
 from discord import app_commands
 from discord.ext import commands
-from utils import setup_logging, send_discord_message
+from utils import send_discord_message, setup_logging
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -35,7 +35,7 @@ class ModalCog(commands.Cog):
         thread = None
         try:
             if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
-                await interaction.response.send_message(
+                await send_discord_message(
                     "Please provide a Python (.py) or CUDA (.cu) file"
                 )
                 return None

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -4,7 +4,7 @@ import discord
 import modal
 from discord import app_commands
 from discord.ext import commands
-from utils import setup_logging, send_discord_message
+from utils import send_discord_message, setup_logging
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -4,7 +4,7 @@ import discord
 import modal
 from discord import app_commands
 from discord.ext import commands
-from utils import setup_logging
+from utils import setup_logging, send_discord_message
 
 logger = setup_logging()
 
@@ -31,7 +31,6 @@ class ModalCog(commands.Cog):
         interaction: discord.Interaction,
         script: discord.Attachment,
         gpu_type: app_commands.Choice[str],
-        use_followup: bool = False
     ) -> discord.Thread:
         thread = None
         try:
@@ -45,10 +44,7 @@ class ModalCog(commands.Cog):
             queue_start_time = time.perf_counter()
             message = f"Created thread {thread.mention} for your Modal job"
 
-            if use_followup:
-                await interaction.followup.send(message)
-            else:
-                await interaction.response.send_message(message)
+            await send_discord_message(interaction, message)
 
             await thread.send(f"**Processing `{script.filename}` with {gpu_type.name}...**")
 

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -7,7 +7,7 @@ from cogs.github_cog import GitHubCog
 from cogs.modal_cog import ModalCog
 from discord import app_commands
 from discord.ext import commands
-from utils import setup_logging, send_discord_message
+from utils import send_discord_message, setup_logging
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -48,7 +48,7 @@ class VerifyRunCog(commands.Cog):
     ) -> bool:
         github_command = github_cog.run_github
         github_thread = await github_command.callback(
-            github_cog, interaction, script_file, choice, use_followup=True
+            github_cog, interaction, script_file, choice
         )
 
         message_contents = [
@@ -98,7 +98,7 @@ class VerifyRunCog(commands.Cog):
         modal_command = modal_cog.run_modal
 
         modal_thread = await modal_command.callback(
-            modal_cog, interaction, script_file, t4, use_followup=True
+            modal_cog, interaction, script_file, t4
         )
 
         message_contents = [

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -7,7 +7,7 @@ from cogs.github_cog import GitHubCog
 from cogs.modal_cog import ModalCog
 from discord import app_commands
 from discord.ext import commands
-from utils import setup_logging
+from utils import setup_logging, send_discord_message
 
 logger = setup_logging()
 
@@ -72,8 +72,9 @@ class VerifyRunCog(commands.Cog):
         )
 
         if all_patterns_found:
-            await interaction.followup.send(
-                f"✅ GitHub run ({choice.name}) completed successfully - all expected messages found!"
+            send_discord_message(
+                interaction,
+                f"✅ GitHub run ({choice.name}) completed successfully - all expected messages found!",
             )
             return True
         else:
@@ -85,9 +86,10 @@ class VerifyRunCog(commands.Cog):
                     for content in message_contents
                 )
             ]
-            await interaction.followup.send(
+            send_discord_message(
+                interaction,
                 f"❌ GitHub run ({choice.name}) verification failed. Missing expected messages:\n"
-                + "\n".join(f"- {pattern}" for pattern in missing_patterns)
+                + "\n".join(f"- {pattern}" for pattern in missing_patterns),
             )
             return False
 
@@ -120,8 +122,9 @@ class VerifyRunCog(commands.Cog):
         )
 
         if all_patterns_found:
-            await interaction.followup.send(
-                "✅ Modal run completed successfully - all expected messages found!"
+            send_discord_message(
+                interaction,
+                "✅ Modal run completed successfully - all expected messages found!",
             )
             return True
         else:
@@ -133,9 +136,10 @@ class VerifyRunCog(commands.Cog):
                     for content in message_contents
                 )
             ]
-            await interaction.followup.send(
+            send_discord_message(
+                interaction,
                 "❌ Modal run verification failed. Missing expected messages:\n"
-                + "\n".join(f"- {pattern}" for pattern in missing_patterns)
+                + "\n".join(f"- {pattern}" for pattern in missing_patterns),
             )
             return False
 
@@ -151,7 +155,7 @@ class VerifyRunCog(commands.Cog):
             github_cog = self.bot.get_cog("GitHubCog")
 
             if not all([modal_cog, github_cog]):
-                await interaction.response.send_message("❌ Required cogs not found!")
+                await send_discord_message(interaction, "❌ Required cogs not found!")
                 return
 
             nvidia = app_commands.Choice(name="NVIDIA", value="nvidia")
@@ -164,14 +168,15 @@ class VerifyRunCog(commands.Cog):
             )
 
             if all(results):
-                await interaction.followup.send("✅ All runs completed successfully!")
+                send_discord_message(interaction, "✅ All runs completed successfully!")
             else:
-                await interaction.followup.send(
-                    "❌ Some runs failed! Consult messages above for details."
+                send_discord_message(
+                    interaction,
+                    "❌ Some runs failed! Consult messages above for details.",
                 )
 
         except Exception as e:
             logger.error(f"Error starting verification runs: {e}", exc_info=True)
-            await interaction.followup.send(
-                f"❌ Problem performing verification runs: {str(e)}"
+            send_discord_message(
+                interaction, f"❌ Problem performing verification runs: {str(e)}"
             )

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -58,7 +58,7 @@ class LeaderboardDB:
         """Context manager exit"""
         self.disconnect()
 
-    def create_leaderboard(self, leaderboard: LeaderboardItem):
+    def create_leaderboard(self, leaderboard: LeaderboardItem) -> Optional[None]:
         try:
             self.cursor.execute(
                 """
@@ -75,6 +75,8 @@ class LeaderboardDB:
         except psycopg2.Error as e:
             print(f"Error during leaderboard creation: {e}")
             self.connection.rollback()  # Ensure rollback if error occurs
+            return "Error during leaderboard creation."
+        return None
 
     def create_submission(self, submission: SubmissionItem):
         try:
@@ -98,7 +100,9 @@ class LeaderboardDB:
             self.connection.rollback()  # Ensure rollback if error occurs
 
     def get_leaderboards(self) -> list[LeaderboardItem]:
-        self.cursor.execute("SELECT id, name, deadline, reference_code FROM leaderboard.problem")
+        self.cursor.execute(
+            "SELECT id, name, deadline, reference_code FROM leaderboard.problem"
+        )
 
         return [
             LeaderboardItem(id=lb[0], name=lb[1], deadline=lb[2], reference_code=lb[3])
@@ -108,7 +112,7 @@ class LeaderboardDB:
     def get_leaderboard(self, leaderboard_name: str) -> int | None:
         self.cursor.execute(
             "SELECT id, name, deadline, reference_code FROM leaderboard.problem WHERE name = %s",
-            (leaderboard_name,)
+            (leaderboard_name,),
         )
 
         res = self.cursor.fetchone()

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -73,9 +73,8 @@ class LeaderboardDB:
             )
             self.connection.commit()
         except psycopg2.Error as e:
-            print(f"Error during leaderboard creation: {e}")
             self.connection.rollback()  # Ensure rollback if error occurs
-            return "Error during leaderboard creation."
+            return f"Error during leaderboard creation: {e}"
         return None
 
     def create_submission(self, submission: SubmissionItem):

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -3,6 +3,7 @@ import logging
 import re
 import subprocess
 from typing import List, TypedDict
+
 import discord
 
 

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import re
 import subprocess
-from typing import TypedDict, List
+from typing import List, TypedDict
 
 
 def setup_logging():

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -3,6 +3,7 @@ import logging
 import re
 import subprocess
 from typing import List, TypedDict
+import discord
 
 
 def setup_logging():
@@ -56,6 +57,19 @@ async def get_user_from_id(id, interaction, bot):
             return username
         else:
             return id
+
+
+async def send_discord_message(
+    interaction: discord.Interaction, msg: str, **kwargs
+) -> None:
+    """
+    To get around response messages in slash commands that are
+    called externally, send a message using the followup.
+    """
+    if interaction.response.is_done():
+        await interaction.followup.send(msg, **kwargs)
+    else:
+        await interaction.response.send_message(msg, **kwargs)
 
 
 def extract_score(score_str: str) -> float:

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import re
 import subprocess
-from typing import TypedDict
+from typing import TypedDict, List
 
 
 def setup_logging():
@@ -73,6 +73,7 @@ class LeaderboardItem(TypedDict):
     name: str
     deadline: datetime.datetime
     reference_code: str
+    gpu_types: List[str]
 
 
 class SubmissionItem(TypedDict):


### PR DESCRIPTION
## Description

To avoid issues where Discord complains about the correct usage of send / followup, we add a wrapper that checks which is valid, and uses the correct command. This feature is important for callbacks, where an existing response might exist, despite the GitHub slash command function assuming it does not.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
