### PR TITLE
Refactor Leaderboard Submission Eval Code.

### DIFF
--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
         run: |
           if [[ -n "${{ github.event.inputs.eval_content }}" ]]; then
-            if [[ "${{ github.event.inputs.eval_content }}" == *.cu ]]; then
+            if [[ "${{ github.event.inputs.eval_filename }}" == *.cu ]]; then
               echo "Compiling and running CUDA file..."
               nvcc "${{ github.event.inputs.eval_filename }}" -o cuda_program
               ./cuda_program > training.log 2>&1

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -79,7 +79,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 f"Ran on Modal. Leaderboard '{leaderboard_name}'.\n"
                 + f"Submission title: {script.filename}.\n"
                 + f"Submission user: {interaction.user.id}.\n"
-                + f"Runtime: {score} ms",
+                + f"Runtime: {score:.9f} seconds.",
                 ephemeral=True,
             )
         except ValueError:

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -39,9 +39,7 @@ class LeaderboardSubmitCog(app_commands.Group):
         gpu_type="Choose the GPU type for Modal",
     )
     @app_commands.choices(
-        gpu_type=[
-            app_commands.Choice(name=gpu.value, value=gpu.value) for gpu in ModalGPU
-        ]
+        gpu_type=[app_commands.Choice(name=gpu.value, value=gpu.value) for gpu in ModalGPU]
     )
     async def submit_modal(
         self,
@@ -90,16 +88,12 @@ class LeaderboardSubmitCog(app_commands.Group):
             )
 
     ### GITHUB SUBCOMMAND
-    @app_commands.command(
-        name="github", description="Submit leaderboard data for GitHub"
-    )
+    @app_commands.command(name="github", description="Submit leaderboard data for GitHub")
     @app_commands.describe(
         gpu_type="Choose the GPU type for Github Runners",
     )
     @app_commands.choices(
-        gpu_type=[
-            app_commands.Choice(name=gpu.name, value=gpu.value) for gpu in GitHubGPU
-        ]
+        gpu_type=[app_commands.Choice(name=gpu.name, value=gpu.value) for gpu in GitHubGPU]
     )
     async def submit_github(
         self,
@@ -157,9 +151,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 print(f"Webhook not found: {e}")
                 await send_discord_message(interaction, "❌ The webhook was not found.")
 
-            message_contents = [
-                msg.content async for msg in github_thread.history(limit=None)
-            ]
+            message_contents = [msg.content async for msg in github_thread.history(limit=None)]
 
             # Compute eval or submission score, call runner here.
             # TODO: Make this more robust later
@@ -180,14 +172,17 @@ class LeaderboardSubmitCog(app_commands.Group):
                 if interaction.user.nick is None
                 else interaction.user.nick
             )
+
             await send_discord_message(
                 interaction,
                 "Successfully ran on GitHub runners!\n"
                 + f"Leaderboard '{leaderboard_name}'.\n"
                 + f"Submission title: {script.filename}.\n"
-                + f"Submission user: {user_id}\n"
-                + f"Runtime: {score} ms\n",
+                + f"Submission user: {user_id}.\n"
+                + f"Runtime: {score:.9f} seconds.",
+                ephemeral=True,
             )
+
         except ValueError:
             await send_discord_message(
                 interaction,
@@ -225,9 +220,7 @@ class GPUSelectionView(ui.View):
 class LeaderboardCog(commands.Cog):
     def __init__(self, bot):
         self.bot: commands.Bot = bot
-        self.get_leaderboards = bot.leaderboard_group.command(name="list")(
-            self.get_leaderboards
-        )
+        self.get_leaderboards = bot.leaderboard_group.command(name="list")(self.get_leaderboards)
         self.leaderboard_create = bot.leaderboard_group.command(
             name="create", description="Create a new leaderboard"
         )(self.leaderboard_create)
@@ -246,9 +239,7 @@ class LeaderboardCog(commands.Cog):
             leaderboards = db.get_leaderboards()
 
         if not leaderboards:
-            await send_discord_message(
-                interaction, "No leaderboards found.", ephemeral=True
-            )
+            await send_discord_message(interaction, "No leaderboards found.", ephemeral=True)
             return
 
         # Create embed
@@ -257,9 +248,7 @@ class LeaderboardCog(commands.Cog):
         # Add fields for each leaderboard
         for lb in leaderboards:
             deadline_str = lb["deadline"].strftime("%Y-%m-%d %H:%M")
-            embed.add_field(
-                name=lb["name"], value=f"Deadline: {deadline_str}", inline=False
-            )
+            embed.add_field(name=lb["name"], value=f"Deadline: {deadline_str}", inline=False)
 
         await interaction.followup.send(interaction, embed=embed)
 
@@ -318,7 +307,7 @@ class LeaderboardCog(commands.Cog):
                     if "duplicate key" in err:
                         await send_discord_message(
                             interaction,
-                            'Error: Tried to create a leaderboard '
+                            "Error: Tried to create a leaderboard "
                             f'"{leaderboard_name}" that already exists.',
                             ephemeral=True,
                         )
@@ -383,9 +372,7 @@ class LeaderboardCog(commands.Cog):
             )
 
             for submission in submissions:
-                user_id = await get_user_from_id(
-                    submission["user_id"], interaction, self.bot
-                )
+                user_id = await get_user_from_id(submission["user_id"], interaction, self.bot)
 
                 embed.add_field(
                     name=f"{user_id}: {submission['submission_name']}",

--- a/src/discord-cluster-manager/leaderboard_eval.py
+++ b/src/discord-cluster-manager/leaderboard_eval.py
@@ -3,10 +3,56 @@
 ########
 
 py_eval = """
-from reference import metric
+import torch
+import time
+from reference import ref_kernel, generate_input
+from train import custom_kernel
+
+
+def check_implementation():
+    for _ in range(10):  # check multiple times
+        input_tensors = generate_input()
+        for input in input_tensors:
+            custom_output = custom_kernel(input, dim=-1)
+            ref_output = ref_kernel(input, dim=-1)
+
+            if not torch.allclose(custom_output, ref_output, atol=1e-5):
+                print("mismatch found! custom implementation doesn't match reference.")
+                return
+
+    print("custom implementation matches the reference implementation.")
+
+
+def metric():
+    warmup_runs = 10
+    timed_runs = 100
+
+    # warmup
+    print("warming up...")
+    for _ in range(warmup_runs):
+        input_tensors = generate_input()
+        for input in input_tensors:
+            _ = custom_kernel(input, dim=-1)
+            _ = ref_kernel(input, dim=-1)
+
+    # timing
+    print("timing custom implementation...")
+    input_tensor = generate_input()
+    start_time = time.time()
+    for _ in range(timed_runs):
+        for input in input_tensors:
+            _ = custom_kernel(input, dim=-1)
+
+    custom_duration = (time.time() - start_time) / timed_runs
+
+    print(f"submitted kernel runtime: {custom_duration:.4f} seconds")
+
+    return custom_duration
 
 def main():
+    check_implementation()
     s = metric()
+
     print(f'score:{s}')
 
 if __name__ == '__main__':

--- a/src/discord-cluster-manager/leaderboard_eval.py
+++ b/src/discord-cluster-manager/leaderboard_eval.py
@@ -17,10 +17,10 @@ def check_implementation():
             ref_output = ref_kernel(input, dim=-1)
 
             if not torch.allclose(custom_output, ref_output, atol=1e-5):
-                print("mismatch found! custom implementation doesn't match reference.")
+                print('mismatch found! custom implementation doesn't match reference.')
                 return
 
-    print("custom implementation matches the reference implementation.")
+    print('custom implementation matches the reference implementation.')
 
 
 def metric():
@@ -28,7 +28,7 @@ def metric():
     timed_runs = 100
 
     # warmup
-    print("warming up...")
+    print('warming up...')
     for _ in range(warmup_runs):
         input_tensors = generate_input()
         for input in input_tensors:
@@ -36,7 +36,7 @@ def metric():
             _ = ref_kernel(input, dim=-1)
 
     # timing
-    print("timing custom implementation...")
+    print('timing custom implementation...')
     input_tensor = generate_input()
     start_time = time.time()
     for _ in range(timed_runs):
@@ -45,7 +45,7 @@ def metric():
 
     custom_duration = (time.time() - start_time) / timed_runs
 
-    print(f"submitted kernel runtime: {custom_duration:.4f} seconds")
+    print(f'submitted kernel runtime: {custom_duration:.4f} seconds')
 
     return custom_duration
 

--- a/src/discord-cluster-manager/leaderboard_eval.py
+++ b/src/discord-cluster-manager/leaderboard_eval.py
@@ -9,18 +9,19 @@ from reference import ref_kernel, generate_input
 from train import custom_kernel
 
 
-def check_implementation():
+def check_implementation() -> bool:
     for _ in range(10):  # check multiple times
         input_tensors = generate_input()
         for input in input_tensors:
-            custom_output = custom_kernel(input, dim=-1)
-            ref_output = ref_kernel(input, dim=-1)
+            custom_output = custom_kernel(input)
+            ref_output = ref_kernel(input)
 
             if not torch.allclose(custom_output, ref_output, atol=1e-5):
                 print('mismatch found! custom implementation doesnt match reference.')
-                return
+                return False
 
     print('custom implementation matches the reference implementation.')
+    return True
 
 
 def metric():
@@ -32,8 +33,8 @@ def metric():
     for _ in range(warmup_runs):
         input_tensors = generate_input()
         for input in input_tensors:
-            _ = custom_kernel(input, dim=-1)
-            _ = ref_kernel(input, dim=-1)
+            _ = custom_kernel(input)
+            _ = ref_kernel(input)
 
     # timing
     print('timing custom implementation...')
@@ -41,7 +42,7 @@ def metric():
     start_time = time.time()
     for _ in range(timed_runs):
         for input in input_tensors:
-            _ = custom_kernel(input, dim=-1)
+            _ = custom_kernel(input)
 
     custom_duration = (time.time() - start_time) / timed_runs
 
@@ -50,7 +51,7 @@ def metric():
     return custom_duration
 
 def main():
-    check_implementation()
+    assert (check_implementation())
     s = metric()
 
     print(f'score:{s}')

--- a/src/discord-cluster-manager/leaderboard_eval.py
+++ b/src/discord-cluster-manager/leaderboard_eval.py
@@ -17,7 +17,7 @@ def check_implementation():
             ref_output = ref_kernel(input, dim=-1)
 
             if not torch.allclose(custom_output, ref_output, atol=1e-5):
-                print('mismatch found! custom implementation doesn't match reference.')
+                print('mismatch found! custom implementation doesnt match reference.')
                 return
 
     print('custom implementation matches the reference implementation.')


### PR DESCRIPTION
## Description

The old leaderboard submission eval code expects a `metric()` function from the reference code specified by the leaderboard creator. Instead, we only expect the leaderboard creator to have 2 functions: the reference kernel itself, and an input data generator. We now handle checking implementations and runtimes on our end to avoid hacking and to allow us to quickly fix leaderboard issues. This change was per last Tuesday's meeting.

We will probably update `leaderboard_eval.py` over time, this is just a simple implementation to start that is usable for Python / Triton.

Example of what new reference code may look like for softmax:
```
import torch
from typing import List

def ref_kernel(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
    """
    Reference implementation of the Softmax function using PyTorch's predefined functions.
    Args:
        x (torch.Tensor): Input tensor.
        dim (int): Dimension along which to apply softmax.
    Returns:
        torch.Tensor: Tensor after applying Softmax.
    """
    return torch.nn.functional.softmax(x, dim=dim)


def generate_input(seed: int = None, to_cuda: bool = True) -> List[torch.Tensor]:
    """
    Generates random input tensor of the specified shape.
    Args:
        seed (int): Random seed for reproducibility.
    Returns:
        torch.Tensor: Randomly generated tensor.
    """
    shapes = [(128, 64), (256, 64), (512, 64)]
    device = torch.device("cuda" if to_cuda else "cpu")

    if seed is not None:
        torch.manual_seed(seed)

    tensors = []
    for shape in shapes:
        tensors.append(torch.randn(shape, device=device))

    return tensors
```

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
