### PR TITLE
rename problem table to leaderboard

### DIFF
--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -70,7 +70,7 @@ class LeaderboardDB:
         try:
             self.cursor.execute(
                 """
-                INSERT INTO leaderboard.problem (name, deadline, reference_code)
+                INSERT INTO leaderboard.leaderboard (name, deadline, reference_code)
                 VALUES (%s, %s, %s)
                 """,
                 (
@@ -89,9 +89,10 @@ class LeaderboardDB:
         try:
             self.cursor.execute(
                 """
-                INSERT INTO leaderboard.submission (problem_id, name, user_id,
-                    code, submission_time, score)
-                VALUES ((SELECT id FROM leaderboard.problem WHERE name = %s),
+                INSERT INTO leaderboard.submission (leaderboard_id, name,
+                    user_id, code, submission_time, score)
+                VALUES (
+                    (SELECT id FROM leaderboard.leaderboard WHERE name = %s),
                     %s, %s, %s, %s, %s)
                 """,
                 (
@@ -110,7 +111,10 @@ class LeaderboardDB:
 
     def get_leaderboards(self) -> list[LeaderboardItem]:
         self.cursor.execute(
-            "SELECT id, name, deadline, reference_code FROM leaderboard.problem"
+            """
+            SELECT id, name, deadline, reference_code
+            FROM leaderboard.leaderboard
+            """
         )
 
         return [
@@ -122,7 +126,7 @@ class LeaderboardDB:
         self.cursor.execute(
             """
             SELECT id, name, deadline, reference_code
-            FROM leaderboard.problem
+            FROM leaderboard.leaderboard
             WHERE name = %s
             """,
             (leaderboard_name,),
@@ -144,9 +148,9 @@ class LeaderboardDB:
             """
             SELECT s.name, s.user_id, s.code, s.submission_time, s.score
             FROM leaderboard.submission s
-            JOIN leaderboard.problem p
-            ON s.problem_id = p.id
-            WHERE p.name = %s
+            JOIN leaderboard.leaderboard l
+            ON s.leaderboard_id = l.id
+            WHERE l.name = %s
             ORDER BY s.score ASC
             """,
             (leaderboard_name,),

--- a/src/discord-cluster-manager/migrations/20241221_01_54Oeg-rename-problem-table.py
+++ b/src/discord-cluster-manager/migrations/20241221_01_54Oeg-rename-problem-table.py
@@ -1,0 +1,45 @@
+"""
+This migration renames the table leaderboard.problem to leaderboard.leaderboard,
+and renames associated foreign keys, indexes, and constraints.
+"""
+
+from yoyo import step
+
+__depends__ = {'20241214_01_M62BX-drop-old-leaderboard-tables'}
+
+steps = [
+    # Rename leaderboard.problem to leaderboard.leaderboard:
+    step("ALTER TABLE leaderboard.problem RENAME TO leaderboard"),
+    step("""
+         ALTER SEQUENCE leaderboard.problem_id_seq
+         RENAME TO leaderboard_id_seq
+         """),
+    step("ALTER INDEX leaderboard.problem_pkey RENAME TO leaderboard_pkey"),
+    step("""
+         ALTER TABLE leaderboard.leaderboard
+         RENAME CONSTRAINT problem_name_key
+         TO leaderboard_name_key
+         """),
+
+    # Rename a column in leaderboard.submission:
+    step("""
+         ALTER TABLE leaderboard.submission 
+         RENAME COLUMN problem_id
+         TO leaderboard_id
+         """),
+    step("""
+         ALTER TABLE leaderboard.submission
+         RENAME CONSTRAINT submission_problem_id_fkey
+         TO submission_leaderboard_id_fkey
+         """),
+
+    # We need to update the name for the index
+    # leaderboard.submission_problem_id_idx. We can't just rename the index,
+    # because the index definition refers to the old column name, problem_id.
+    # This might be confusing, so we drop and re-create the index:
+    step("DROP INDEX leaderboard.submission_problem_id_idx"),
+    step("""
+         CREATE INDEX submission_leaderboard_id_idx
+         ON leaderboard.submission (leaderboard_id)
+         """)
+]

--- a/src/discord-cluster-manager/migrations/20241221_01_54Oeg-rename-problem-table.py
+++ b/src/discord-cluster-manager/migrations/20241221_01_54Oeg-rename-problem-table.py
@@ -23,7 +23,7 @@ steps = [
 
     # Rename a column in leaderboard.submission:
     step("""
-         ALTER TABLE leaderboard.submission 
+         ALTER TABLE leaderboard.submission
          RENAME COLUMN problem_id
          TO leaderboard_id
          """),


### PR DESCRIPTION
## Description

The table for storing data about leaderboard challenges was named `problem`. This didn't seem like a good name, and @alexzhang13 expressed a preference for the name `leaderboard`.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
