### PR TITLE
stop sending interaction in leaderboard list

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -250,7 +250,7 @@ class LeaderboardCog(commands.Cog):
             deadline_str = lb["deadline"].strftime("%Y-%m-%d %H:%M")
             embed.add_field(name=lb["name"], value=f"Deadline: {deadline_str}", inline=False)
 
-        await interaction.followup.send(interaction, embed=embed)
+        await interaction.followup.send("", embed=embed)
 
     @discord.app_commands.describe(
         leaderboard_name="Name of the leaderboard",


### PR DESCRIPTION
## Description

This change removes a bit of extra text that gets displayed in the `/leaderboard list` output.

Before this change:

![image](https://github.com/user-attachments/assets/cff379d0-1268-4483-b2fa-82015235a269)

After this change:

![image](https://github.com/user-attachments/assets/62d61779-6cf0-487d-83ce-c434d05a1ef7)

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
