### PR TITLE
adds table and column to track gpu types

### DIFF
--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -72,6 +72,7 @@ class LeaderboardDB:
                 """
                 INSERT INTO leaderboard.leaderboard (name, deadline, reference_code)
                 VALUES (%s, %s, %s)
+                RETURNING id
                 """,
                 (
                     leaderboard["name"],
@@ -79,6 +80,18 @@ class LeaderboardDB:
                     leaderboard["reference_code"],
                 ),
             )
+
+            leaderboard_id = self.cursor.fetchone()[0]
+
+            for gpu_type in leaderboard["gpu_types"]:
+                self.cursor.execute(
+                    """
+                    INSERT INTO leaderboard.gpu_type (leaderboard_id, gpu_type)
+                    VALUES (%s, %s)
+                    """,
+                    (leaderboard_id, gpu_type)
+                )
+
             self.connection.commit()
         except psycopg2.Error as e:
             self.connection.rollback()  # Ensure rollback if error occurs

--- a/src/discord-cluster-manager/migrations/20241222_01_ELxU5-add-gpu-types.py
+++ b/src/discord-cluster-manager/migrations/20241222_01_ELxU5-add-gpu-types.py
@@ -1,0 +1,26 @@
+"""
+This migration adds a table to track the GPU types for a leaderboard,
+and adds a column to track the GPU type for a run.
+"""
+
+from yoyo import step
+
+__depends__ = {'20241221_01_54Oeg-rename-problem-table'}
+
+steps = [
+    step("""
+         CREATE TABLE leaderboard.gpu_type (
+             leaderboard_id INTEGER NOT NULL
+                 REFERENCES leaderboard.leaderboard(id),
+             gpu_type TEXT NOT NULL,
+             PRIMARY KEY (leaderboard_id, gpu_type)
+         )
+         """,
+         "DROP TABLE leaderboard.gpu_type"),
+    step("""
+         ALTER TABLE leaderboard.runinfo ADD COLUMN gpu_type TEXT NOT NULL
+         """,
+         """
+         ALTER TABLE leaderboard.runinfo DROP COLUMN gpu_type
+         """)
+]


### PR DESCRIPTION
## Description

This PR adds a table to the leaderboard schema to track the GPU types for each leaderboard. It also adds a column to the runinfo table to track the GPU type that the run used.

After creating a leaderboard named `gpu_types` using `/leaderboard create`:

```
clusterdev=# select name, id from leaderboard.leaderboard;
     name     | id 
--------------+----
 softmax_test |  1
 gpu_types    |  3
(2 rows)

clusterdev=# select * from leaderboard.gpu_type where leaderboard_id = 3;
 leaderboard_id | gpu_type 
----------------+----------
              3 | NVIDIA
              3 | AMD
(2 rows)
```

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
