### PR TITLE
`/leaderboard list` now shows all leaderboards with associated GPU types

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -1,4 +1,5 @@
 import random
+import textwrap
 from datetime import datetime
 
 import discord
@@ -6,7 +7,6 @@ from consts import GitHubGPU, ModalGPU
 from discord import Interaction, SelectOption, app_commands, ui
 from discord.ext import commands
 from utils import extract_score, get_user_from_id, send_discord_message, setup_logging
-import textwrap
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -6,6 +6,7 @@ from consts import GitHubGPU, ModalGPU
 from discord import Interaction, SelectOption, app_commands, ui
 from discord.ext import commands
 from utils import extract_score, get_user_from_id, send_discord_message, setup_logging
+import textwrap
 
 logger = setup_logging()
 
@@ -244,11 +245,31 @@ class LeaderboardCog(commands.Cog):
 
         # Create embed
         embed = discord.Embed(title="Active Leaderboards", color=discord.Color.blue())
+        padding = " " * 4
+        header = f"{'Name':<20}{padding}{'Deadline':<10}{padding}{'GPU Types':<18}\n"
+        divider = "-" * 56  # Fixed discord bot length
+        rows = []
 
         # Add fields for each leaderboard
         for lb in leaderboards:
-            deadline_str = lb["deadline"].strftime("%Y-%m-%d %H:%M")
-            embed.add_field(name=lb["name"], value=f"Deadline: {deadline_str}", inline=False)
+            name_lines = textwrap.wrap(lb["name"], 20)
+            gpu_types_lines = textwrap.wrap(", ".join(lb["gpu_types"]), 18)
+
+            # Text wrapping logic for long names / multiple GPU displays
+            max_lines = max(len(name_lines), len(gpu_types_lines), 1)
+            deadline_str = lb["deadline"].strftime("%Y-%m-%d")
+
+            for i in range(max_lines):
+                name_part = name_lines[i] if i < len(name_lines) else ""
+                deadline_part = deadline_str if i == 0 else ""  # Deadline only on the first row
+                gpu_types_part = gpu_types_lines[i] if i < len(gpu_types_lines) else ""
+
+                rows.append(
+                    f"{name_part:<20}{padding}{deadline_part:<10}{padding}{gpu_types_part:<18}"
+                )
+
+        # Add the formatted text to the embed as a code block
+        embed.description = f"```\n{header}{divider}\n" + "\n".join(rows) + "\n```"
 
         await interaction.followup.send("", embed=embed)
 

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -14,7 +14,14 @@ from utils import LeaderboardItem, SubmissionItem
 
 
 class LeaderboardDB:
-    def __init__(self, host: str, database: str, user: str, password: str, port: str = "5432"):
+    def __init__(
+        self,
+        host: str,
+        database: str,
+        user: str,
+        password: str,
+        port: str = "5432"
+    ):
         """Initialize database connection parameters"""
         self.connection_params = {
             "host": host,
@@ -56,7 +63,10 @@ class LeaderboardDB:
         """Context manager exit"""
         self.disconnect()
 
-    def create_leaderboard(self, leaderboard: LeaderboardItem) -> Optional[None]:
+    def create_leaderboard(
+        self,
+        leaderboard: LeaderboardItem
+    ) -> Optional[None]:
         try:
             self.cursor.execute(
                 """
@@ -154,7 +164,9 @@ class LeaderboardDB:
         else:
             return None
 
-    def get_leaderboard_submissions(self, leaderboard_name: str) -> list[SubmissionItem]:
+    def get_leaderboard_submissions(
+        self, leaderboard_name: str
+    ) -> list[SubmissionItem]:
         self.cursor.execute(
             """
             SELECT s.name, s.user_id, s.code, s.submission_time, s.score


### PR DESCRIPTION
## Description

`/leaderboard list` now shows the name, deadline, and associated GPU types all linted properly. Eventually, we'll want to **move a lot of the rendering code to another function and clean up constants to const.py**, but this is a first working version.

<img width="589" alt="Screenshot 2024-12-22 at 9 32 14 PM" src="https://github.com/user-attachments/assets/8bd1e916-af6e-4097-99de-723cb1d3a06f" />

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
