### PR TITLE
Feat/lb delete

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -425,7 +425,9 @@ class LeaderboardCog(commands.Cog):
             err = db.delete_leaderboard(leaderboard_name)
 
             if err:
-                await send_discord_message(interaction, f"Error: {err}", ephemeral=True)
+                await send_discord_message(
+                    interaction, "An error occurred while deleting the leaderboard.", ephemeral=True
+                )
             else:
                 await send_discord_message(
                     interaction,

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -232,6 +232,10 @@ class LeaderboardCog(commands.Cog):
             name="show", description="Get all submissions for a leaderboard"
         )(self.get_leaderboard_submissions)
 
+        self.delete_leaderboard = bot.leaderboard_group.command(
+            name="delete", description="Delete a leaderboard"
+        )(self.delete_leaderboard)
+
     async def get_leaderboards(self, interaction: discord.Interaction):
         """Display all leaderboards in a table format"""
         await interaction.response.defer()
@@ -413,4 +417,18 @@ class LeaderboardCog(commands.Cog):
             else:
                 await send_discord_message(
                     interaction, "An unknown error occurred.", ephemeral=True
+                )
+
+    @discord.app_commands.describe(leaderboard_name="Name of the leaderboard")
+    async def delete_leaderboard(self, interaction: discord.Interaction, leaderboard_name: str):
+        with self.bot.leaderboard_db as db:
+            err = db.delete_leaderboard(leaderboard_name)
+
+            if err:
+                await send_discord_message(interaction, f"Error: {err}", ephemeral=True)
+            else:
+                await send_discord_message(
+                    interaction,
+                    f"Leaderboard '{leaderboard_name}' deleted.",
+                    ephemeral=True,
                 )

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -98,6 +98,21 @@ class LeaderboardDB:
             return f"Error during leaderboard creation: {e}"
         return None
 
+    def delete_leaderboard(self, leaderboard_name: str) -> Optional[str]:
+        try:
+            # TODO: wait for cascade to be implemented
+            self.cursor.execute(
+                """
+                DELETE FROM leaderboard.leaderboard WHERE name = %s
+                """,
+                (leaderboard_name,),
+            )
+            self.connection.commit()
+        except psycopg2.Error as e:
+            self.connection.rollback()
+            return f"Error during leaderboard deletion: {e}"
+        return None
+
     def create_submission(self, submission: SubmissionItem):
         try:
             self.cursor.execute(


### PR DESCRIPTION
## Description

Enables a `/leaderboard delete {name}` command. This PR just handles the logic, will implement a user verification (probably discord role based) in the subsequent PR). 
<img width="384" alt="image" src="https://github.com/user-attachments/assets/f9488c91-a610-4452-99a1-2c42d475dfd4" />

<img width="433" alt="image" src="https://github.com/user-attachments/assets/38d50a3e-1f7d-4fcb-a149-9ac81a47f390" />

<img width="719" alt="image" src="https://github.com/user-attachments/assets/d0ae0fd0-66c3-4e77-b324-617bd58fd28c" />



Also showcasees how to do a db-based autocomplete for discord commands.

Currently a draft, depends on #71. EDIT: Ready to merge @alexzhang13 



## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
