### PR TITLE
changed foreign keys to 'on delete cascade'

### DIFF
--- a/src/discord-cluster-manager/migrations/20241224_01_Pg4FX-delete-cascade.py
+++ b/src/discord-cluster-manager/migrations/20241224_01_Pg4FX-delete-cascade.py
@@ -8,7 +8,7 @@ from yoyo import step
 __depends__ = {'20241222_01_ELxU5-add-gpu-types'}
 
 steps = [
-    # submission table    
+    # submission table
     step(
         """
         ALTER TABLE leaderboard.submission

--- a/src/discord-cluster-manager/migrations/20241224_01_Pg4FX-delete-cascade.py
+++ b/src/discord-cluster-manager/migrations/20241224_01_Pg4FX-delete-cascade.py
@@ -1,0 +1,61 @@
+"""
+This migration changes all existing foreign key constraints to be 'on delete
+cascade'.
+"""
+
+from yoyo import step
+
+__depends__ = {'20241222_01_ELxU5-add-gpu-types'}
+
+steps = [
+    # submission table    
+    step(
+        """
+        ALTER TABLE leaderboard.submission
+        DROP CONSTRAINT submission_leaderboard_id_fkey
+        """
+    ),
+    step(
+        """
+        ALTER TABLE leaderboard.submission
+        ADD CONSTRAINT submission_leaderboard_id_fkey
+        FOREIGN KEY (leaderboard_id)
+        REFERENCES leaderboard.leaderboard(id)
+        ON DELETE CASCADE
+        """
+    ),
+
+    # runinfo table
+    step(
+        """
+        ALTER TABLE leaderboard.runinfo
+        DROP CONSTRAINT runinfo_submission_id_fkey
+        """
+    ),
+    step(
+        """
+        ALTER TABLE leaderboard.runinfo
+        ADD CONSTRAINT runinfo_submission_id_fkey
+        FOREIGN KEY (submission_id)
+        REFERENCES leaderboard.submission(id)
+        ON DELETE CASCADE
+        """
+    ),
+
+    # gpu_type table
+    step(
+        """
+        ALTER TABLE leaderboard.gpu_type
+        DROP CONSTRAINT gpu_type_leaderboard_id_fkey
+        """
+    ),
+    step(
+        """
+        ALTER TABLE leaderboard.gpu_type
+        ADD CONSTRAINT gpu_type_leaderboard_id_fkey
+        FOREIGN KEY (leaderboard_id)
+        REFERENCES leaderboard.leaderboard(id)
+        ON DELETE CASCADE
+        """
+    ),
+]


### PR DESCRIPTION
## Description

This PR changes foreign key constraints to 'on delete cascade'.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
