### PR TITLE
Add support for submitting to specific GPUs per leaderboard and show

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -230,7 +230,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                     github_cog,
                     gpu,
                 )
-                for gpu in gpus
+                for gpu in view.selected_gpus
             ]
             await asyncio.gather(*tasks)
 

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -1,7 +1,7 @@
+import asyncio
 import random
 import textwrap
 from datetime import datetime
-import asyncio
 
 import discord
 from consts import GitHubGPU, ModalGPU
@@ -9,11 +9,10 @@ from discord import Interaction, SelectOption, app_commands, ui
 from discord.ext import commands
 from leaderboard_db import leaderboard_name_autocomplete
 from utils import (
+    display_lb_submissions,
     extract_score,
-    get_user_from_id,
     send_discord_message,
     setup_logging,
-    display_lb_submissions,
 )
 
 logger = setup_logging()
@@ -52,15 +51,17 @@ async def async_submit_github_job(
     score = extract_score("".join(message_contents))
 
     with bot.leaderboard_db as db:
-        db.create_submission({
-            "submission_name": script.filename,
-            "submission_time": datetime.now(),
-            "leaderboard_name": leaderboard_name,
-            "code": submission_content,
-            "user_id": interaction.user.id,
-            "submission_score": score,
-            "gpu_type": gpu,
-        })
+        db.create_submission(
+            {
+                "submission_name": script.filename,
+                "submission_time": datetime.now(),
+                "leaderboard_name": leaderboard_name,
+                "code": submission_content,
+                "user_id": interaction.user.id,
+                "submission_score": score,
+                "gpu_type": gpu,
+            }
+        )
 
     user_id = (
         interaction.user.global_name if interaction.user.nick is None else interaction.user.nick
@@ -132,15 +133,17 @@ class LeaderboardSubmitCog(app_commands.Group):
             score = random.random()
 
             with self.bot.leaderboard_db as db:
-                db.create_submission({
-                    "submission_name": script.filename,
-                    "submission_time": datetime.now(),
-                    "leaderboard_name": leaderboard_name,
-                    "code": submission_content,
-                    "user_id": interaction.user.id,
-                    "submission_score": score,
-                    "gpu_type": gpu_type.name,
-                })
+                db.create_submission(
+                    {
+                        "submission_name": script.filename,
+                        "submission_time": datetime.now(),
+                        "leaderboard_name": leaderboard_name,
+                        "code": submission_content,
+                        "user_id": interaction.user.id,
+                        "submission_score": score,
+                        "gpu_type": gpu_type.name,
+                    }
+                )
 
             await send_discord_message(
                 interaction,
@@ -404,12 +407,14 @@ class LeaderboardCog(commands.Cog):
             template_content = await reference_code.read()
 
             with self.bot.leaderboard_db as db:
-                err = db.create_leaderboard({
-                    "name": leaderboard_name,
-                    "deadline": date_value,
-                    "reference_code": template_content.decode("utf-8"),
-                    "gpu_types": view.selected_gpus,
-                })
+                err = db.create_leaderboard(
+                    {
+                        "name": leaderboard_name,
+                        "deadline": date_value,
+                        "reference_code": template_content.decode("utf-8"),
+                        "gpu_types": view.selected_gpus,
+                    }
+                )
 
                 if err:
                     if "duplicate key" in err:

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 import discord
 import psycopg2
@@ -219,10 +219,13 @@ class LeaderboardDB:
             return None
 
     # TODO: add GPU type
-    def get_leaderboard_submissions(self, leaderboard_name: str, gpu_name: str) -> list[SubmissionItem]:
+    def get_leaderboard_submissions(
+        self, leaderboard_name: str, gpu_name: str
+    ) -> list[SubmissionItem]:
         self.cursor.execute(
             """
-            SELECT s.name, s.user_id, s.code, s.submission_time, s.score, s.gpu_type
+            SELECT s.name, s.user_id, s.code, s.submission_time, s.score,
+            s.gpu_type
             FROM leaderboard.submission s
             JOIN leaderboard.leaderboard l
             ON s.leaderboard_id = l.id

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 import discord
 import psycopg2
@@ -180,6 +180,27 @@ class LeaderboardDB:
 
         return leaderboards
 
+    def get_leaderboard_gpu_types(self, leaderboard_name: str) -> List[str] | None:
+        self.cursor.execute(
+            """
+            SELECT *
+            FROM leaderboard.gpu_type
+            WHERE leaderboard_id = (
+                SELECT id
+                FROM leaderboard.leaderboard
+                WHERE name = %s
+            )
+            """,
+            (leaderboard_name,),
+        )
+
+        gpu_types = [x[1] for x in self.cursor.fetchall()]
+
+        if gpu_types:
+            return gpu_types
+        else:
+            return None
+
     def get_leaderboard(self, leaderboard_name: str) -> int | None:
         self.cursor.execute(
             """
@@ -198,17 +219,17 @@ class LeaderboardDB:
             return None
 
     # TODO: add GPU type
-    def get_leaderboard_submissions(self, leaderboard_name: str) -> list[SubmissionItem]:
+    def get_leaderboard_submissions(self, leaderboard_name: str, gpu_name: str) -> list[SubmissionItem]:
         self.cursor.execute(
             """
-            SELECT s.name, s.user_id, s.code, s.submission_time, s.score
+            SELECT s.name, s.user_id, s.code, s.submission_time, s.score, s.gpu_type
             FROM leaderboard.submission s
             JOIN leaderboard.leaderboard l
             ON s.leaderboard_id = l.id
-            WHERE l.name = %s
+            WHERE l.name = %s AND s.gpu_type = %s
             ORDER BY s.score ASC
             """,
-            (leaderboard_name,),
+            (leaderboard_name, gpu_name),
         )
 
         return [
@@ -219,6 +240,7 @@ class LeaderboardDB:
                 code=submission[2],
                 submission_time=submission[3],
                 submission_score=submission[4],
+                gpu_type=gpu_name,
             )
             for submission in self.cursor.fetchall()
         ]


### PR DESCRIPTION
## Description
This PR adds functionality for submitting to a leaderboard with certain GPUs, and showing the results (these go hand-in-hand currently, so I didn't separate the PRs).

As an example:
<img width="613" alt="Screenshot 2024-12-26 at 6 26 33 PM" src="https://github.com/user-attachments/assets/cae5a95f-83d1-43b8-aa3d-980367e1dde9" />

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
