### PR TITLE
Allow user submissions to have arbitrary names

### DIFF
--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -55,6 +55,7 @@ class GitHubCog(commands.Cog):
         try:
             script_content = (await script.read()).decode("utf-8")
             selected_gpu = GPUType.AMD if gpu_type.value == "amd" else GPUType.NVIDIA
+            filename = "train.py" if script.filename.endswith(".py") else "train.cu"
 
             if reference_script is not None or reference_code is not None:
                 reference_content = (
@@ -66,15 +67,13 @@ class GitHubCog(commands.Cog):
 
                 run_id = await self.trigger_github_action(
                     script_content,
-                    script.filename,
+                    filename,
                     selected_gpu,
                     reference_content,
                     eval_code,
                 )
             else:
-                run_id = await self.trigger_github_action(
-                    script_content, script.filename, selected_gpu
-                )
+                run_id = await self.trigger_github_action(script_content, filename, selected_gpu)
 
             if run_id:
                 await thread.send(

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -180,7 +180,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                         "code": submission_content,
                         "user_id": interaction.user.id,
                         "submission_score": score,
-                         # TODO: Change this to multiple GPUs (see above)
+                        # TODO: Change this to multiple GPUs (see above)
                         "gpu_type": "nvidia",
                     }
                 )
@@ -423,7 +423,6 @@ class LeaderboardCog(commands.Cog):
         self,
         interaction: discord.Interaction,
         leaderboard_name: str,
-        # TODO add GPU type
     ):
         try:
             with self.bot.leaderboard_db as db:


### PR DESCRIPTION
## Description

Super simple change to make sure all the reference code / eval code doesn't complain when a user submits a file not named "train.py".

![image](https://github.com/user-attachments/assets/ed0e3a57-8a59-4e35-b4bf-17d4fe134e6b)

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
