### PR TITLE
Remove GPU Selection UI on slash commands.

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -266,6 +266,11 @@ class GPUSelectionView(ui.View):
             view=None,
             delete_after=0.0001,  # Get rid of the original message
         )
+        await send_discord_message(
+            interaction,
+            f"Selected GPUs: {', '.join(self.selected_gpus)}",
+            ephemeral=True,
+        )
         self.stop()
 
 

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -260,10 +260,11 @@ class GPUSelectionView(ui.View):
         # Retrieve the selected options
         select = interaction.data["values"]
         self.selected_gpus = select
-        await send_discord_message(
-            interaction,
-            f"Selected GPUs: {', '.join(self.selected_gpus)}",
-            ephemeral=True,
+
+        # Edit the message to remove the view and update the content
+        await interaction.response.edit_message(
+            view=None,
+            delete_after=0.0001,  # Get rid of the original message
         )
         self.stop()
 

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -266,6 +266,7 @@ class GPUSelectionView(ui.View):
             view=None,
             delete_after=0.0001,  # Get rid of the original message
         )
+        # Send a new message with the selected GPUs
         await send_discord_message(
             interaction,
             f"Selected GPUs: {', '.join(self.selected_gpus)}",

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -116,7 +116,7 @@ async def display_lb_submissions(interaction, bot, leaderboard_name: str, gpu: s
             inline=False,
         )
 
-    await interaction.followup.send(embed=embed)
+    await interaction.followup.send(embed=embed, ephemeral=True)
 
 
 class LRUCache:


### PR DESCRIPTION
## Description

We forcibly delete the selection UI so it's not visible to other users. This removes clutter on the Discord chat, and also prevents other users from interacting with a useless UI.

Old:
<img width="559" alt="Screenshot 2024-12-29 at 11 45 42 PM" src="https://github.com/user-attachments/assets/d82cb392-0fc8-4f28-b351-2d2e75d870a9" />


Example:
<img width="460" alt="Screenshot 2024-12-29 at 11 45 14 PM" src="https://github.com/user-attachments/assets/b495a77e-9b81-4033-b04c-3713e3c388c6" />

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
