### PR TITLE
Update README with new reference script expectations for Python / CUDA.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,24 +253,25 @@ analysis for the leaderboard. The difficult of CUDA evaluation scripts is we nee
 handle the typing system for tensors. The `reference.cu` that the leaderboard creator submits must have
 the following function signatures with their implementations filled out:
 
-The main difference is we now need to define an alias for the type that the input / output list of
-tensors take. A simple solution is to pre-define an array of `const int` sizes, then define an array
-of containers, e.g. `std::array<std::vector<float>, N_SIZES>`.
+The main difference is we now need to define an alias for the type that the input / outputs are. A
+simple and common example is a list of FP32 tensors, which can be defined using a pre-defined array of 
+`const int`s called `N_SIZES`, then define an array of containers, e.g. 
+`std::array<std::vector<float>, N_SIZES>`.
 
 ```cuda
-// (List of) Tensor types as input, e.g. using input_t = std::array<std::vector<float>, IN_SIZES>;
+// User-defined type for inputs, e.g. using input_t = std::array<std::vector<float>, IN_SIZES>;
 using input_t = ...;
 
-// (List of) Tensor types as outputs, e.g. using output_t = std::array<std::vector<float>, OUT_SIZES>;
+// User-defined type for outputs, e.g. using output_t = std::array<std::vector<float>, OUT_SIZES>;
 using output_t = ...;
 
-// Generate random (list of) tensors
+// Generate random data of type input_t
 input_t generate_input() {
     // Implement me...
 }
 
 
-// Reference kernel (over list of data), host code.
+// Reference kernel host code.
 output_t reference(input_t data) {
     // Implement me...
 }

--- a/README.md
+++ b/README.md
@@ -240,11 +240,47 @@ def ref_kernel(input: torch.Tensor) -> torch.Tensor:
 # Generate a list of tensors as input to the kernel
 def generate_input() -> List[torch.Tensor]:
     # Implement me...
+
+# Verify correctness of reference and output
+def check_implementation(input: torch.Tensor, output: torch.Tensor) -> bool:
+    # Implement me...
 ```
 
 #### Reference Code Requirements (CUDA)
 
-TODO. This is currently a work in progress.
+The Discord bot internally contains an `eval.cu` script that handles the correctness and timing
+analysis for the leaderboard. The difficult of CUDA evaluation scripts is we need to explicitly
+handle the typing system for tensors. The `reference.cu` that the leaderboard creator submits must have
+the following function signatures with their implementations filled out:
+
+The main difference is we now need to define an alias for the type that the input / output list of
+tensors take. A simple solution is to pre-define an array of `const int` sizes, then define an array
+of containers, e.g. `std::array<std::vector<float>, N_SIZES>`.
+
+```cuda
+// (List of) Tensor types as input, e.g. using input_t = std::array<std::vector<float>, IN_SIZES>;
+using input_t = ...;
+
+// (List of) Tensor types as outputs, e.g. using output_t = std::array<std::vector<float>, OUT_SIZES>;
+using output_t = ...;
+
+// Generate random (list of) tensors
+input_t generate_input() {
+    // Implement me...
+}
+
+
+// Reference kernel (over list of data), host code.
+output_t reference(input_t data) {
+    // Implement me...
+}
+
+
+// Verify correctness of reference and output
+bool check_implementation(output_t out, output_t ref) {
+    // Implement me...
+}
+```
 
 ### Submitting to a Leaderboard
 


### PR DESCRIPTION
## Description

Add reference kernel function signatures for CUDA, also update Python reference kernel function signatures.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
