### PR TITLE
Requirement set up and 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ data/
 node_modules/
 package-lock.json
 package.json
+*.ini

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyGithub
 aiohttp
 discord.py
-audioop-lts # discord.py imports using * syntax 
+# audioop-lts # discord.py imports using * syntax 
 python-dotenv
 requests
 modal

--- a/scripts/flush_db.py
+++ b/scripts/flush_db.py
@@ -20,7 +20,7 @@ def flush_database():
     try:
         # Connect to database
         print("📡 Connecting to database...")
-        connection = psycopg2.connect(DATABASE_URL, sslmode="require")
+        connection = psycopg2.connect(DATABASE_URL)
         cursor = connection.cursor()
 
         # Drop existing tables

--- a/src/discord-cluster-manager/cogs/misc_cog.py
+++ b/src/discord-cluster-manager/cogs/misc_cog.py
@@ -49,7 +49,7 @@ class BotManagerCog(commands.Cog):
             return
 
         try:
-            with psycopg2.connect(DATABASE_URL, sslmode="require") as conn:
+            with psycopg2.connect(DATABASE_URL) as conn:
                 with conn.cursor() as cursor:
                     cursor.execute("SELECT RANDOM()")
                     result = cursor.fetchone()

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -52,7 +52,7 @@ class LeaderboardDB:
         """Establish connection to the database"""
         try:
             self.connection = (
-                psycopg2.connect(DATABASE_URL, sslmode="require")
+                psycopg2.connect(DATABASE_URL)
                 if DATABASE_URL
                 else psycopg2.connect(**self.connection_params)
             )


### PR DESCRIPTION
## Description

Please provide a summary of the changes in this pull request.
* Disable `audioop-lts` pip package as not sure why it is needed. We like to use Python `3.11` but this makes it use `3.13`
* Get rid of SSL requirements for local dev server set up. Mayb we need this for staging, but be good to not require this in debug mode?

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
