### PR TITLE
Finish up Modal support + Example of ThunderKittens working

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -1,7 +1,8 @@
 import asyncio
 from datetime import datetime
+from enum import Enum
 from io import StringIO
-from typing import Optional
+from typing import List, Optional
 
 import discord
 from consts import (
@@ -24,70 +25,186 @@ from utils import (
 logger = setup_logging()
 
 
-async def async_submit_github_job(
-    interaction: discord.Interaction,
-    leaderboard_name: str,
-    script: discord.Attachment,
-    github_command,
-    reference_code,
-    bot,
-    submission_content,
-    github_cog: commands.Cog,
-    gpu: str,
-):
-    try:
-        github_thread = await github_command.callback(
-            github_cog,
-            interaction,
-            script,
-            app_commands.Choice(
-                name=gpu,
-                value=GitHubGPU[gpu].value,
-            ),
-            reference_code=reference_code,
-        )
-    except discord.errors.NotFound as e:
-        print(f"Webhook not found: {e}")
-        await send_discord_message(interaction, "❌ The webhook was not found.")
-
-    message_contents = [msg.content async for msg in github_thread.history(limit=None)]
-
-    # Compute eval or submission score, call runner here.
-    # TODO: Make this more robust later
-    score = extract_score("".join(message_contents))
-
-    with bot.leaderboard_db as db:
-        db.create_submission(
-            {
-                "submission_name": script.filename,
-                "submission_time": datetime.now(),
-                "leaderboard_name": leaderboard_name,
-                "code": submission_content,
-                "user_id": interaction.user.id,
-                "submission_score": score,
-                "gpu_type": gpu,
-            }
-        )
-
-    user_id = (
-        interaction.user.global_name if interaction.user.nick is None else interaction.user.nick
-    )
-
-    await send_discord_message(
-        interaction,
-        f"Successfully ran on {gpu} using GitHub runners!\n"
-        + f"Leaderboard '{leaderboard_name}'.\n"
-        + f"Submission title: {script.filename}.\n"
-        + f"Submission user: {user_id}.\n"
-        + f"Runtime: {score:.9f} seconds.",
-        ephemeral=True,
-    )
-
-
 class LeaderboardSubmitCog(app_commands.Group):
     def __init__(self, bot):
         super().__init__(name="submit", description="Submit to leaderboard")
         self.bot = bot
+
+    async def async_submit_cog_job(
+        self,
+        interaction: discord.Interaction,
+        leaderboard_name: str,
+        script: discord.Attachment,
+        command,
+        reference_code,
+        submission_content,
+        cog: commands.Cog,
+        gpu: str,
+        GPUsEnum: Enum = GitHubGPU,
+        runner_name: str = "GitHub",
+    ):
+        try:
+            discord_thread = await command.callback(
+                cog,
+                interaction,
+                script,
+                app_commands.Choice(
+                    name=gpu,
+                    value=GPUsEnum[gpu].value,
+                ),
+                reference_code=reference_code,
+            )
+        except discord.errors.NotFound as e:
+            print(f"Webhook not found: {e}")
+            await send_discord_message(interaction, "❌ The webhook was not found.")
+
+        message_contents = [msg.content async for msg in discord_thread.history(limit=None)]
+
+        # Compute eval or submission score, call runner here.
+        # TODO: Make this more robust later
+        score = extract_score("".join(message_contents))
+
+        with self.bot.leaderboard_db as db:
+            db.create_submission(
+                {
+                    "submission_name": script.filename,
+                    "submission_time": datetime.now(),
+                    "leaderboard_name": leaderboard_name,
+                    "code": submission_content,
+                    "user_id": interaction.user.id,
+                    "submission_score": score,
+                    "gpu_type": gpu,
+                }
+            )
+
+        user_id = (
+            interaction.user.global_name if interaction.user.nick is None else interaction.user.nick
+        )
+
+        await send_discord_message(
+            interaction,
+            f"Successfully ran on {gpu} using {runner_name} runners!\n"
+            + f"Leaderboard '{leaderboard_name}'.\n"
+            + f"Submission title: {script.filename}.\n"
+            + f"Submission user: {user_id}.\n"
+            + f"Runtime: {score:.9f} seconds.",
+            ephemeral=True,
+        )
+
+    async def select_gpu_view(
+        self,
+        interaction: discord.Interaction,
+        leaderboard_name: str,
+        gpus: List[str],
+    ):
+        """
+        UI displayed to user to select GPUs that they want to use.
+        """
+        if not interaction.response.is_done():
+            await interaction.response.defer(ephemeral=True)
+
+        view = GPUSelectionView(gpus)
+
+        await send_discord_message(
+            interaction,
+            f"Please select the GPU(s) for leaderboard: {leaderboard_name}.",
+            view=view,
+            ephemeral=True,
+        )
+
+        await view.wait()
+        return view
+
+    async def before_submit_hook(
+        self,
+        interaction: discord.Interaction,
+        leaderboard_name: str,
+        script: discord.Attachment,
+    ):
+        """
+        Main logic to handle at the beginning of a user submission to a runner, to make
+        sure reference code, deadlines, etc. are all correct.
+        """
+        # Read and convert reference code
+        reference_code = None
+        with self.bot.leaderboard_db as db:
+            leaderboard_item = db.get_leaderboard(leaderboard_name)
+
+            now = datetime.now()
+            deadline = leaderboard_item["deadline"]
+
+            if now.date() > deadline.date():
+                await send_discord_message(
+                    interaction,
+                    f"The deadline to submit to {leaderboard_name} has passed.\n"
+                    + f"It was {deadline.date()} and today is {now.date()}.",
+                )
+                return None
+
+            if not leaderboard_item:
+                await send_discord_message(
+                    interaction,
+                    f"Leaderboard {leaderboard_name} not found.",
+                    ephemeral=True,
+                )
+                return None
+
+            leaderboard_item = db.get_leaderboard(leaderboard_name)
+            gpus = db.get_leaderboard_gpu_types(leaderboard_name)
+            reference_code = leaderboard_item["reference_code"]
+
+        # Read the template file
+        submission_content = await script.read()
+
+        try:
+            submission_content = submission_content.decode()
+        except UnicodeError:
+            await send_discord_message(
+                interaction, "Could not decode your file. Is it UTF-8?", ephemeral=True
+            )
+            return None
+
+        return (reference_code, gpus)
+
+    async def on_submit_hook(
+        self,
+        interaction: discord.Interaction,
+        leaderboard_name: str,
+        script: discord.Attachment,
+        command,
+        cog: commands.Cog,
+    ) -> int:
+        """
+        Called as the main body of a submission to route to the correct runner.
+        """
+        try:
+            reference_code, gpus = await self.before_submit_hook(
+                interaction,
+                leaderboard_name,
+                script,
+            )
+        except Exception:
+            return -1
+
+        # GPU selection View
+        view = await self.select_gpu_view(interaction, leaderboard_name, gpus)
+
+        tasks = [
+            self.async_submit_cog_job(
+                interaction,
+                leaderboard_name,
+                script,
+                command,
+                reference_code,
+                reference_code,
+                cog,
+                gpu,
+            )
+            for gpu in view.selected_gpus
+        ]
+
+        await asyncio.gather(*tasks)
+        return 0
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.channel_id != self.bot.leaderboard_submissions_id:
@@ -122,96 +239,22 @@ class LeaderboardSubmitCog(app_commands.Group):
         leaderboard_name: str,
         script: discord.Attachment,
     ):
-        await interaction.response.defer(ephemeral=True)
-        try:
-            if not script.filename.endswith(".py") and not script.filename.endswith(".cu"):
-                await send_discord_message("Please provide a Python (.py) or CUDA (.cu) file")
-                return None
+        # Call Modal runner
+        modal_cog = self.bot.get_cog("ModalCog")
 
-            # TODO: please add this info to the LB itself
-            lang = "cpp" if script.filename.endswith(".cu") else "py"
-            eval_code = cu_eval if lang == "cpp" else py_eval
+        if not all([modal_cog]):
+            await send_discord_message(interaction, "❌ Required Modal cogs not found!")
+            return
+        modal_runner_command = modal_cog.run_modal
 
-            # Read the template file
-            submission_content = await script.read()
-
-            # Call Modal runner
-            modal_cog = self.bot.get_cog("ModalCog")
-
-            with self.bot.leaderboard_db as db:
-                leaderboard_item = db.get_leaderboard(leaderboard_name)
-                reference_code: bytes = leaderboard_item["reference_code"]
-                gpus = db.get_leaderboard_gpu_types(leaderboard_name)
-
-            view = GPUSelectionView(gpus)
-
-            await send_discord_message(
-                interaction,
-                f"Please select GPUs to submit for leaderboard: {leaderboard_name}.",
-                view=view,
-                ephemeral=True,
-            )
-
-            await view.wait()
-
-            from modal_runner import app
-
-            with app.run():
-                if lang == "cpp":
-                    from modal_runner import run_cuda_script
-
-                    stdout, score = run_cuda_script.remote(
-                        eval_code,
-                        reference_content=reference_code,
-                        submission_content=submission_content.decode("utf-8"),
-                    )
-                else:
-                    from modal_runner import run_pytorch_script
-
-                    stdout, score = run_pytorch_script.remote(
-                        eval_code,
-                        reference_content=reference_code,
-                        submission_content=submission_content.decode("utf-8"),
-                    )
-
-            if not all([modal_cog]):
-                await send_discord_message(interaction, "❌ Required cogs not found!")
-                return
-
-            with self.bot.leaderboard_db as db:
-                db.create_submission(
-                    {
-                        "submission_name": script.filename,
-                        "submission_time": datetime.now(),
-                        "leaderboard_name": leaderboard_name,
-                        "code": submission_content,
-                        "user_id": interaction.user.id,
-                        "submission_score": score,
-                        "gpu_type": view.selected_gpus[0],  # TODO: fix
-                    }
-                )
-
-            user_id = (
-                interaction.user.global_name
-                if interaction.user.nick is None
-                else interaction.user.nick
-            )
-
-            await send_discord_message(
-                interaction,
-                f"Successfully ran on {view.selected_gpus[0]} using Modal runners!\n"
-                + f"Leaderboard '{leaderboard_name}'.\n"
-                + f"Submission title: {script.filename}.\n"
-                + f"Submission user: {user_id}.\n"
-                + f"Runtime: {score:.9f} seconds.",
-                ephemeral=True,
-            )
-        except ValueError:
-            await send_discord_message(
-                interaction,
-                "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
-                ephemeral=True,
-            )
+        success = await self.on_submit_hook(
+            interaction,
+            leaderboard_name,
+            script,
+            modal_runner_command,
+            modal_cog,
+        )
+        return success
 
     @app_commands.command(name="github", description="Submit leaderboard data for GitHub")
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
@@ -221,93 +264,22 @@ class LeaderboardSubmitCog(app_commands.Group):
         leaderboard_name: str,
         script: discord.Attachment,
     ):
-        # Don't allow submissions if deadline is past
-        with self.bot.leaderboard_db as db:
-            leaderboard_item = db.get_leaderboard(leaderboard_name)
+        # Call GH runner
+        github_cog = self.bot.get_cog("GitHubCog")
 
-        # Read the template file
-        submission_content = await script.read()
-
-        try:
-            submission_content = submission_content.decode()
-        except UnicodeError:
-            await send_discord_message(
-                interaction, "Could not decode your file. Is it UTF-8?", ephemeral=True
-            )
+        if not all([github_cog]):
+            await send_discord_message(interaction, "❌ Required cogs not found!")
             return
+        gh_runner_command = github_cog.run_github
 
-        try:
-            # Read and convert reference code
-            reference_code = None
-            with self.bot.leaderboard_db as db:
-                leaderboard_item = db.get_leaderboard(leaderboard_name)
-
-                now = datetime.now()
-                deadline = leaderboard_item["deadline"]
-
-                if now.date() > deadline.date():
-                    await send_discord_message(
-                        interaction,
-                        f"The deadline to submit to {leaderboard_name} has passed.\n"
-                        + f"It was {deadline.date()} and today is {now.date()}.",
-                    )
-                    return
-
-                if not leaderboard_item:
-                    await send_discord_message(
-                        interaction,
-                        f"Leaderboard {leaderboard_name} not found.",
-                        ephemeral=True,
-                    )
-                    return
-                reference_code = leaderboard_item["reference_code"]
-                gpus = db.get_leaderboard_gpu_types(leaderboard_name)
-
-            if not interaction.response.is_done():
-                await interaction.response.defer()
-
-            # Call GH runner
-            github_cog = self.bot.get_cog("GitHubCog")
-
-            if not all([github_cog]):
-                await send_discord_message(interaction, "❌ Required cogs not found!")
-                return
-
-            view = GPUSelectionView(gpus)
-
-            await send_discord_message(
-                interaction,
-                f"Please select GPUs to submit for leaderboard: {leaderboard_name}.",
-                view=view,
-                ephemeral=True,
-            )
-
-            await view.wait()
-
-            github_command = github_cog.run_github
-
-            tasks = [
-                async_submit_github_job(
-                    interaction,
-                    leaderboard_name,
-                    script,
-                    github_command,
-                    reference_code,
-                    self.bot,
-                    reference_code,
-                    github_cog,
-                    gpu,
-                )
-                for gpu in view.selected_gpus
-            ]
-            await asyncio.gather(*tasks)
-
-        except ValueError:
-            await send_discord_message(
-                interaction,
-                "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DD HH:MM",
-                ephemeral=True,
-            )
+        success = await self.on_submit_hook(
+            interaction,
+            leaderboard_name,
+            script,
+            github_cog,
+            gh_runner_command,
+        )
+        return success
 
 
 class LeaderboardCog(commands.Cog):

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -203,6 +203,17 @@ class LeaderboardSubmitCog(app_commands.Group):
             return -1
 
         # GPU selection View
+        gpu_enums = {e.name for e in GPUsEnum}
+        gpus = [gpu for gpu in gpus if gpu in gpu_enums]
+
+        if len(gpus) == 0:
+            await send_discord_message(
+                interaction,
+                "❌ No available GPUs for Leaderboard "
+                + f"`{leaderboard_name}` on {runner_name} runner.",
+            )
+            return -1
+
         view = await self.select_gpu_view(interaction, leaderboard_name, gpus)
 
         tasks = [
@@ -215,7 +226,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 submission_content,
                 cog,
                 gpu,
-                GitHubGPU,  # GPUsEnum, TODO: FIX ME LATER!,
+                GPUsEnum,
                 runner_name,
             )
             for gpu in view.selected_gpus

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import discord
 import modal
+from consts import ModalGPU
 from discord import app_commands
 from discord.ext import commands
 from leaderboard_eval import cu_eval, py_eval
@@ -23,9 +24,7 @@ class ModalCog(commands.Cog):
         script="The Python script file to run", gpu_type="Choose the GPU type for Modal"
     )
     @app_commands.choices(
-        gpu_type=[
-            app_commands.Choice(name="NVIDIA T4", value="t4"),
-        ]
+        gpu_type=[app_commands.Choice(name=gpu.name, value=gpu.value) for gpu in ModalGPU]
     )
     async def run_modal(
         self,
@@ -100,7 +99,8 @@ class ModalCog(commands.Cog):
                 await thread.send(f"**Error:** {str(e)}")
             raise
 
-    async def trigger_modal_run(
+    # TODO: needs cleaning with modal folks
+    async def trigger_modal_run(  # noqa: C901
         self,
         script_content: str,
         filename: str,
@@ -113,36 +113,124 @@ class ModalCog(commands.Cog):
 
         try:
             print(f"Running {filename} with Modal")
+            gpu_type = gpu_type.lower()
             with modal.enable_output():
                 with app.run():
                     if reference_content is not None:
                         if filename.endswith(".py"):
-                            from modal_runner import run_pytorch_script
+                            if gpu_type == "t4":
+                                from modal_runner_archs import run_pytorch_script_t4
 
-                            stdout, score = run_pytorch_script.remote(
-                                py_eval,
-                                reference_content=reference_content,
-                                submission_content=script_content,
-                            )
+                                stdout, score = run_pytorch_script_t4.remote(
+                                    py_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            elif gpu_type == "l4":
+                                from modal_runner_archs import run_pytorch_script_l4
+
+                                stdout, score = run_pytorch_script_l4.remote(
+                                    py_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            elif gpu_type == "a100":
+                                from modal_runner_archs import run_pytorch_script_a100
+
+                                stdout, score = run_pytorch_script_a100.remote(
+                                    py_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            elif gpu_type == "h100":
+                                from modal_runner_archs import run_pytorch_script_h100
+
+                                stdout, score = run_pytorch_script_h100.remote(
+                                    py_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            else:
+                                # Throw error?
+                                stdout, score = None, None
                         else:
-                            from modal_runner import run_cuda_script
+                            if gpu_type == "t4":
+                                from modal_runner_archs import run_cuda_script_t4
 
-                            stdout, score = run_cuda_script.remote(
-                                cu_eval,
-                                reference_content=reference_content,
-                                submission_content=script_content,
-                            )
+                                stdout, score = run_cuda_script_t4.remote(
+                                    cu_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            elif gpu_type == "l4":
+                                from modal_runner_archs import run_cuda_script_l4
+
+                                stdout, score = run_cuda_script_l4.remote(
+                                    cu_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            elif gpu_type == "a100":
+                                from modal_runner_archs import run_cuda_script_a100
+
+                                stdout, score = run_cuda_script_a100.remote(
+                                    cu_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            elif gpu_type == "h100":
+                                from modal_runner_archs import run_cuda_script_h100
+
+                                stdout, score = run_cuda_script_h100.remote(
+                                    cu_eval,
+                                    reference_content=reference_content,
+                                    submission_content=script_content,
+                                )
+                            else:
+                                # Throw error?
+                                stdout, score = None, None
                     else:
                         if filename.endswith(".py"):
-                            from modal_runner import run_pytorch_script
+                            if gpu_type == "t4":
+                                from modal_runner_archs import run_pytorch_script_t4
 
-                            stdout, score = run_pytorch_script.remote(script_content)
+                                stdout, score = run_pytorch_script_t4.remote(script_content)
+                            elif gpu_type == "l4":
+                                from modal_runner_archs import run_pytorch_script_l4
+
+                                stdout, score = run_pytorch_script_l4.remote(script_content)
+                            elif gpu_type == "a100":
+                                from modal_runner_archs import run_pytorch_script_a100
+
+                                stdout, score = run_pytorch_script_a100.remote(script_content)
+                            elif gpu_type == "h100":
+                                from modal_runner_archs import run_pytorch_script_h100
+
+                                stdout, score = run_pytorch_script_h100.remote(script_content)
+                            else:
+                                # Throw error?
+                                stdout, score = None, None
                         elif filename.endswith(".cu"):
-                            from modal_runner import run_cuda_script
+                            if gpu_type == "t4":
+                                from modal_runner_archs import run_cuda_script_t4
 
-                            stdout, score = run_cuda_script.remote(script_content)
+                                stdout, score = run_cuda_script_t4.remote(script_content)
+                            elif gpu_type == "l4":
+                                from modal_runner_archs import run_cuda_script_l4
 
-            print(stdout, score)
+                                stdout, score = run_cuda_script_l4.remote(script_content)
+                            elif gpu_type == "a100":
+                                from modal_runner_archs import run_cuda_script_a100
+
+                                stdout, score = run_cuda_script_a100.remote(script_content)
+                            elif gpu_type == "h100":
+                                from modal_runner_archs import run_cuda_script_h100
+
+                                stdout, score = run_cuda_script_h100.remote(script_content)
+                            else:
+                                # Throw error?
+                                stdout, score = None, None
+
             return stdout, score
 
         except Exception as e:

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -122,118 +122,34 @@ class ModalCog(commands.Cog):
                 with app.run():
                     if reference_content is not None:
                         if filename.endswith(".py"):
-                            if gpu_type == "t4":
-                                from modal_runner_archs import run_pytorch_script_t4
+                            from modal_runner_archs import get_pytorch_modal_runner
 
-                                stdout, score = run_pytorch_script_t4.remote(
-                                    py_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            elif gpu_type == "l4":
-                                from modal_runner_archs import run_pytorch_script_l4
-
-                                stdout, score = run_pytorch_script_l4.remote(
-                                    py_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            elif gpu_type == "a100":
-                                from modal_runner_archs import run_pytorch_script_a100
-
-                                stdout, score = run_pytorch_script_a100.remote(
-                                    py_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            elif gpu_type == "h100":
-                                from modal_runner_archs import run_pytorch_script_h100
-
-                                stdout, score = run_pytorch_script_h100.remote(
-                                    py_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            else:
-                                # Throw error?
-                                stdout, score = None, None
+                            modal_runner = get_pytorch_modal_runner(gpu_type)
+                            stdout, score = modal_runner.remote(
+                                py_eval,
+                                reference_content=reference_content,
+                                submission_content=script_content,
+                            )
                         else:
-                            if gpu_type == "t4":
-                                from modal_runner_archs import run_cuda_script_t4
+                            from modal_runner_archs import get_cuda_modal_runner
 
-                                stdout, score = run_cuda_script_t4.remote(
-                                    cu_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            elif gpu_type == "l4":
-                                from modal_runner_archs import run_cuda_script_l4
-
-                                stdout, score = run_cuda_script_l4.remote(
-                                    cu_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            elif gpu_type == "a100":
-                                from modal_runner_archs import run_cuda_script_a100
-
-                                stdout, score = run_cuda_script_a100.remote(
-                                    cu_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            elif gpu_type == "h100":
-                                from modal_runner_archs import run_cuda_script_h100
-
-                                stdout, score = run_cuda_script_h100.remote(
-                                    cu_eval,
-                                    reference_content=reference_content,
-                                    submission_content=script_content,
-                                )
-                            else:
-                                # Throw error?
-                                stdout, score = None, None
+                            modal_runner = get_cuda_modal_runner(gpu_type)
+                            stdout, score = modal_runner.remote(
+                                cu_eval,
+                                reference_content=reference_content,
+                                submission_content=script_content,
+                            )
                     else:
                         if filename.endswith(".py"):
-                            if gpu_type == "t4":
-                                from modal_runner_archs import run_pytorch_script_t4
+                            from modal_runner_archs import get_pytorch_modal_runner
 
-                                stdout, score = run_pytorch_script_t4.remote(script_content)
-                            elif gpu_type == "l4":
-                                from modal_runner_archs import run_pytorch_script_l4
-
-                                stdout, score = run_pytorch_script_l4.remote(script_content)
-                            elif gpu_type == "a100":
-                                from modal_runner_archs import run_pytorch_script_a100
-
-                                stdout, score = run_pytorch_script_a100.remote(script_content)
-                            elif gpu_type == "h100":
-                                from modal_runner_archs import run_pytorch_script_h100
-
-                                stdout, score = run_pytorch_script_h100.remote(script_content)
-                            else:
-                                # Throw error?
-                                stdout, score = None, None
+                            modal_runner = get_pytorch_modal_runner(gpu_type)
+                            stdout, score = modal_runner.remote(script_content)
                         elif filename.endswith(".cu"):
-                            if gpu_type == "t4":
-                                from modal_runner_archs import run_cuda_script_t4
+                            from modal_runner_archs import get_cuda_modal_runner
 
-                                stdout, score = run_cuda_script_t4.remote(script_content)
-                            elif gpu_type == "l4":
-                                from modal_runner_archs import run_cuda_script_l4
-
-                                stdout, score = run_cuda_script_l4.remote(script_content)
-                            elif gpu_type == "a100":
-                                from modal_runner_archs import run_cuda_script_a100
-
-                                stdout, score = run_cuda_script_a100.remote(script_content)
-                            elif gpu_type == "h100":
-                                from modal_runner_archs import run_cuda_script_h100
-
-                                stdout, score = run_cuda_script_h100.remote(script_content)
-                            else:
-                                # Throw error?
-                                stdout, score = None, None
+                            modal_runner = get_cuda_modal_runner(gpu_type)
+                            stdout, score = modal_runner.remote(script_content)
 
             return stdout, score
 

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -82,6 +82,10 @@ class ModalCog(commands.Cog):
                 await thread.send("check_implementation failed.\n")
                 await status_msg.edit(content="**Running on Modal...**\n> ❌ Job failed!")
                 return thread
+            elif "Error" in result:
+                await thread.send(f"Modal run failed. {result}\n")
+                await status_msg.edit(content="**Running on Modal...**\n> ❌ Job failed!")
+                return thread
 
             if result is not None:
                 await thread.send(f"**score:{score:.9f}**\n```")

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -7,6 +7,16 @@ from consts import ModalGPU
 from discord import app_commands
 from discord.ext import commands
 from leaderboard_eval import cu_eval, py_eval
+from modal_runner_archs import (  # noqa: F401
+    run_cuda_script_a100,
+    run_cuda_script_h100,
+    run_cuda_script_l4,
+    run_cuda_script_t4,
+    run_pytorch_script_a100,
+    run_pytorch_script_h100,
+    run_pytorch_script_l4,
+    run_pytorch_script_t4,
+)
 from utils import send_discord_message, setup_logging
 
 logger = setup_logging()

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -83,7 +83,7 @@ class VerifyRunCog(commands.Cog):
             return False
 
     async def verify_modal_run(self, modal_cog: ModalCog, interaction: discord.Interaction) -> bool:
-        t4 = app_commands.Choice(name="NVIDIA T4", value="t4")
+        t4 = app_commands.Choice(name="T4", value="t4")
         modal_command = modal_cog.run_modal
 
         modal_thread = await modal_command.callback(modal_cog, interaction, script_file, t4)

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Type
 
 
 class GPUType(Enum):
@@ -24,8 +25,47 @@ class ModalGPU(Enum):
     H100 = "H100"
 
 
+def combine_enums(enums: list[Type[Enum]], combined_name: str) -> Enum:
+    combined_members = {}
+    for enum in enums:
+        for name, member in enum.__members__.items():
+            if name in combined_members:
+                raise ValueError(f"Duplicate member name '{name}' found across Enums.")
+            combined_members[name] = member.value
+
+    return Enum(combined_name, combined_members)
+
+
+AllGPU = combine_enums([ModalGPU, GitHubGPU], "AllGPU")
+
+
+GPU_TO_SM = {
+    "T4": 75,
+    "L4": 80,
+    "A100": 80,
+    "H100": 90,
+}
+
+
 # Modal-specific constants
 MODAL_PATH = "/tmp/dcs/"
 MODAL_EVAL_CODE_PATH = "/tmp/dcs/eval.py"
 MODAL_REFERENCE_CODE_PATH = "/tmp/dcs/reference.py"
 MODAL_SUBMISSION_CODE_PATH = "/tmp/dcs/train.py"
+
+
+# Compilation flags for Modal
+CUDA_FLAGS = [
+    "--std=c++20",
+    "-DNDEBUG",
+    "-Xcompiler=-Wno-psabi",
+    "-Xcompiler=-fno-strict-aliasing",
+    "--expt-extended-lambda",
+    "--expt-relaxed-constexpr",
+    "-forward-unknown-to-host-compiler",
+    "-O3",
+    "-Xnvlink=--verbose",
+    "-Xptxas=--verbose",
+    "-Xptxas=--warn-on-spills",
+]
+MODAL_CUDA_INCLUDE_DIRS = ["-I/ThunderKittens/include"]

--- a/src/discord-cluster-manager/modal_runner.py
+++ b/src/discord-cluster-manager/modal_runner.py
@@ -223,6 +223,8 @@ def run_cuda_script(  # # noqa: C901
                 capture_output=True,
                 text=True,
             )
+
+            ## FOR DEBUGGING
             compilation_output = compile_process.stdout
             compilation_error = compile_process.stderr
 
@@ -243,6 +245,7 @@ def run_cuda_script(  # # noqa: C901
             print("err", compilation_error)
 
             print("return code", compile_process.returncode)
+            ## FOR DEBUGGING
 
             if compile_process.returncode != 0:
                 raise RuntimeError(

--- a/src/discord-cluster-manager/modal_runner_archs.py
+++ b/src/discord-cluster-manager/modal_runner_archs.py
@@ -1,0 +1,199 @@
+# This file contains wrapper functions for running
+# Modal apps on specific devices. We will fix this later.
+
+from modal_runner import app, cuda_image, run_cuda_script, run_pytorch_script
+
+
+# T4: sm_70 (CUDA 7.x, Maxwell Architecture)
+@app.function(
+    gpu="T4",
+    image=cuda_image,
+)
+def run_cuda_script_t4(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_cuda_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=75,
+    )
+
+
+@app.function(
+    gpu="T4",
+    image=cuda_image,
+)
+def run_pytorch_script_t4(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_pytorch_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=75,  # Targeting T4 (sm_75)
+    )
+
+
+# L4: sm_80 (L4 Tensor Core architecture)
+@app.function(
+    gpu="L4",
+    image=cuda_image,
+)
+def run_cuda_script_l4(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_cuda_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=80,
+    )
+
+
+@app.function(
+    gpu="L4",
+    image=cuda_image,
+)
+def run_pytorch_script_l4(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_pytorch_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=80,  # Targeting L4 (sm_80)
+    )
+
+
+# A100: sm_80 (Ampere architecture)
+@app.function(
+    gpu="A100",
+    image=cuda_image,
+)
+def run_cuda_script_a100(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_cuda_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=80,
+    )
+
+
+@app.function(
+    gpu="A100",
+    image=cuda_image,
+)
+def run_pytorch_script_a100(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_pytorch_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=80,  # Targeting A100 (sm_80)
+    )
+
+
+# H100: sm_90 (Hopper architecture)
+@app.function(
+    gpu="H100",
+    image=cuda_image,
+)
+def run_cuda_script_h100(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_cuda_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=90,
+    )
+
+
+@app.function(
+    gpu="H100",
+    image=cuda_image,
+)
+def run_pytorch_script_h100(
+    script_content: str,
+    reference_content: str = None,
+    submission_content: str = None,
+    timeout_seconds: int = 600,
+) -> tuple[str, float]:
+    return run_pytorch_script(
+        script_content,
+        reference_content,
+        submission_content,
+        timeout_seconds,
+        arch=90,  # Targeting H100 (sm_90)
+    )
+
+
+pytorch_function_map = {
+    "t4": run_pytorch_script_t4,
+    "l4": run_pytorch_script_l4,
+    "a100": run_pytorch_script_a100,
+    "h100": run_pytorch_script_h100,
+}
+
+cuda_function_map = {
+    "t4": run_cuda_script_t4,
+    "l4": run_cuda_script_l4,
+    "a100": run_cuda_script_a100,
+    "h100": run_cuda_script_h100,
+}
+
+
+def get_pytorch_modal_runner(gpu_type: str):
+    """
+    Returns the appropriate PyTorch function for the given gpu_type.
+    """
+    function = pytorch_function_map.get(gpu_type.lower())
+
+    if function:
+        return function
+    else:
+        raise ValueError(f"Function for gpu_type {gpu_type} not found")
+
+
+def get_cuda_modal_runner(gpu_type: str):
+    """
+    Dynamically imports the appropriate CUDA function based on the gpu_type.
+    """
+    function = cuda_function_map.get(gpu_type.lower())
+
+    if function:
+        return function
+    else:
+        raise ValueError(f"Function for gpu_type {gpu_type} not found")

--- a/src/discord-cluster-manager/modal_runner_archs.py
+++ b/src/discord-cluster-manager/modal_runner_archs.py
@@ -1,6 +1,7 @@
 # This file contains wrapper functions for running
 # Modal apps on specific devices. We will fix this later.
 
+from consts import GPU_TO_SM
 from modal_runner import app, cuda_image, run_cuda_script, run_pytorch_script
 
 
@@ -20,7 +21,7 @@ def run_cuda_script_t4(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=75,
+        arch=GPU_TO_SM["T4"],
     )
 
 
@@ -39,7 +40,7 @@ def run_pytorch_script_t4(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=75,  # Targeting T4 (sm_75)
+        arch=GPU_TO_SM["T4"],
     )
 
 
@@ -59,7 +60,7 @@ def run_cuda_script_l4(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=80,
+        arch=GPU_TO_SM["L4"],
     )
 
 
@@ -78,7 +79,7 @@ def run_pytorch_script_l4(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=80,  # Targeting L4 (sm_80)
+        arch=GPU_TO_SM["L4"],
     )
 
 
@@ -98,7 +99,7 @@ def run_cuda_script_a100(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=80,
+        arch=GPU_TO_SM["A100"],
     )
 
 
@@ -117,7 +118,7 @@ def run_pytorch_script_a100(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=80,  # Targeting A100 (sm_80)
+        arch=GPU_TO_SM["A100"],
     )
 
 
@@ -137,7 +138,7 @@ def run_cuda_script_h100(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=90,
+        arch=GPU_TO_SM["H100"],
     )
 
 
@@ -156,7 +157,7 @@ def run_pytorch_script_h100(
         reference_content,
         submission_content,
         timeout_seconds,
-        arch=90,  # Targeting H100 (sm_90)
+        arch=GPU_TO_SM["H100"],
     )
 
 
@@ -176,9 +177,6 @@ cuda_function_map = {
 
 
 def get_pytorch_modal_runner(gpu_type: str):
-    """
-    Returns the appropriate PyTorch function for the given gpu_type.
-    """
     function = pytorch_function_map.get(gpu_type.lower())
 
     if function:
@@ -188,9 +186,6 @@ def get_pytorch_modal_runner(gpu_type: str):
 
 
 def get_cuda_modal_runner(gpu_type: str):
-    """
-    Dynamically imports the appropriate CUDA function based on the gpu_type.
-    """
     function = cuda_function_map.get(gpu_type.lower())
 
     if function:


### PR DESCRIPTION
## Description

This is a relatively large PR with a lot of finishing changes for modal support and ThunderKittens (TK) support.

Namely,

1. We can compile (only tested on just importing and building) ThunderKittens kernel on Modal. More extensive testing coming.
2. The UI for Modal actually works now, and the GPUs you submit to are correct. You can now submit to whatever GPUs you want. You can also submit to more than just the T4s now.
3. A big re-factor to greatly simplify Modal runner code, and merge most of the GitHub runner logic to also work with Modal. The GH/Modal runner logic is now <30 lines.
4. We currently add clone TK when setting up the Modal image, but we may want to do this differently. Happy to make changes in the future.
5. The Modal runners run the Modal Cog, similar to the GitHub runner. This helps a lot with modularity and removing the need to design two different functions for running code on Modal.

Some potential issues for the future:
* I frequently run into "Modal GPUs not hydrated" when starting up the bot. Not sure if this just means the resources aren't ready, but this issue goes away quickly.
* The way we implement multiple modal GPU runners is really disgusting, and it has to do with the function wrappers. I actually had multiple attempts at this that didn't work, but it's hard to distinguish between the issue above and an actual issue. I will return to this later, as I think the current solution is unsatisfactory (we should still just push it for now because it "works").

## Screenshots
<img width="522" alt="Screenshot 2025-01-07 at 12 45 24 AM" src="https://github.com/user-attachments/assets/8097e958-633f-491d-9e51-0ed9c49c61aa" />

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
