### PR TITLE
Vectors Add - Pytorch CUDA inline and Triton example

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,12 @@ support multiple GPU types yet)
 /leaderboard show {name: str}
 ```
 
+Display all personal scores (runtime) from a specific leaderboard.
+
+```
+/leaderboard show-personal {name: str}
+```
+
 #### GPU Kernel-specific Commands
 
 We plan to add support for the PyTorch profiler and CUDA NSight Compute CLI to allow users to

--- a/examples/vectoradd_cuda_inline/reference.py
+++ b/examples/vectoradd_cuda_inline/reference.py
@@ -1,0 +1,37 @@
+import torch
+from typing import List, Tuple
+
+def generate_input() -> List[List[torch.Tensor]]:
+    configs = [
+        (1024, 1024),
+        (1024, 2048),
+        (2048, 2048),
+        (4096, 4096),
+    ]
+    
+    return [[
+        torch.randn(M, N, device='cuda', dtype=torch.float16).contiguous(),
+        torch.randn(M, N, device='cuda', dtype=torch.float16).contiguous()
+    ] for M, N in configs]
+
+def ref_kernel(inputs: List[List[torch.Tensor]]) -> List[torch.Tensor]:
+    return [A + B for A, B in inputs]
+
+def check_implementation(
+    custom_outputs: List[torch.Tensor],
+    reference_outputs: List[torch.Tensor],
+    rtol: float = 1e-4,
+    atol: float = 1e-4
+) -> bool:
+    if len(custom_outputs) != len(reference_outputs):
+        return False
+    
+    for i, (custom_output, reference_output) in enumerate(zip(custom_outputs, reference_outputs)):
+        if custom_output.shape != reference_output.shape:
+            return False
+        
+        if not torch.allclose(custom_output, reference_output, rtol=rtol, atol=atol):
+            max_diff = torch.max(torch.abs(custom_output - reference_output)).item()
+            return False
+    
+    return True

--- a/examples/vectoradd_cuda_inline/submission.py
+++ b/examples/vectoradd_cuda_inline/submission.py
@@ -1,0 +1,72 @@
+import torch
+from torch.utils.cpp_extension import load_inline
+
+add_cuda_source = """
+template <typename scalar_t>
+__global__ void add_kernel(const scalar_t* __restrict__ A, 
+                           const scalar_t* __restrict__ B, 
+                           scalar_t* __restrict__ C, 
+                           int N) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (idx < N) {
+        C[idx] = A[idx] + B[idx];
+    }
+}
+
+torch::Tensor add_cuda(torch::Tensor A, torch::Tensor B) {
+    TORCH_CHECK(A.device().is_cuda(), "Tensor A must be a CUDA tensor");
+    TORCH_CHECK(B.device().is_cuda(), "Tensor B must be a CUDA tensor");
+    TORCH_CHECK(A.sizes() == B.sizes(), "Input tensors must have the same size");
+    
+    int N = A.numel();  
+    auto C = torch::empty_like(A); 
+
+    const int threads = 256; 
+    const int blocks = (N + threads - 1) / threads;  
+    
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(A.scalar_type(), "add_kernel", ([&] {
+        add_kernel<scalar_t><<<blocks, threads>>>(
+            A.data_ptr<scalar_t>(),
+            B.data_ptr<scalar_t>(),
+            C.data_ptr<scalar_t>(),
+            N
+        );
+    }));
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        throw std::runtime_error(cudaGetErrorString(err));
+    }
+
+    return C;
+}
+"""
+
+add_cpp_source = """
+#include <torch/extension.h>
+
+torch::Tensor add_cuda(torch::Tensor A, torch::Tensor B);
+"""
+
+
+
+add_module = load_inline(
+    name='add_cuda',
+    cpp_sources=add_cpp_source,
+    cuda_sources=add_cuda_source,
+    functions=['add_cuda'],
+    verbose=True,
+)
+
+def add(A, B):
+    if not A.is_cuda or not B.is_cuda:
+        raise RuntimeError("Both tensors must be on GPU")
+    return add_module.add_cuda(A, B)
+
+def custom_kernel(inputs):
+    outputs = []
+    for A, B in inputs:
+        output = add(A, B)
+        outputs.append(output)
+    return outputs

--- a/examples/vectoradd_triton/reference.py
+++ b/examples/vectoradd_triton/reference.py
@@ -1,0 +1,37 @@
+import torch
+from typing import List, Tuple
+
+def generate_input() -> List[List[torch.Tensor]]:
+    configs = [
+        (1024, 1024),
+        (1024, 2048),
+        (2048, 2048),
+        (4096, 4096),
+    ]
+    
+    return [[
+        torch.randn(M, N, device='cuda', dtype=torch.float16).contiguous(),
+        torch.randn(M, N, device='cuda', dtype=torch.float16).contiguous()
+    ] for M, N in configs]
+
+def ref_kernel(inputs: List[List[torch.Tensor]]) -> List[torch.Tensor]:
+    return [A + B for A, B in inputs]
+
+def check_implementation(
+    custom_outputs: List[torch.Tensor],
+    reference_outputs: List[torch.Tensor],
+    rtol: float = 1e-4,
+    atol: float = 1e-4
+) -> bool:
+    if len(custom_outputs) != len(reference_outputs):
+        return False
+    
+    for i, (custom_output, reference_output) in enumerate(zip(custom_outputs, reference_outputs)):
+        if custom_output.shape != reference_output.shape:
+            return False
+        
+        if not torch.allclose(custom_output, reference_output, rtol=rtol, atol=atol):
+            max_diff = torch.max(torch.abs(custom_output - reference_output)).item()
+            return False
+    
+    return True

--- a/examples/vectoradd_triton/submission.py
+++ b/examples/vectoradd_triton/submission.py
@@ -1,0 +1,40 @@
+import torch
+import triton
+import triton.language as tl
+
+# Triton kernel
+@triton.jit
+def add_kernel(
+    A_ptr, B_ptr, C_ptr, M, N,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    col_idx = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    
+    mask_row = row_idx < M
+    mask_col = col_idx < N
+
+    A = tl.load(A_ptr + row_idx[:, None] * N + col_idx[None, :], mask=mask_row[:, None] & mask_col[None, :], other=0.0)
+    B = tl.load(B_ptr + row_idx[:, None] * N + col_idx[None, :], mask=mask_row[:, None] & mask_col[None, :], other=0.0)
+
+    C = A + B
+    tl.store(C_ptr + row_idx[:, None] * N + col_idx[None, :], C, mask=mask_row[:, None] & mask_col[None, :])
+
+def custom_kernel(inputs):
+    outputs = []
+    for input_tensor in inputs:
+        A, B = input_tensor
+        M, N = A.shape
+
+        C = torch.empty_like(A)
+
+        BLOCK_SIZE = 32
+        grid = (triton.cdiv(M, BLOCK_SIZE), triton.cdiv(N, BLOCK_SIZE))
+
+        add_kernel[grid](
+            A, B, C, M, N,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+        outputs.append(C)
+    return outputs


### PR DESCRIPTION
## Description

Implemented two sample of vectors add:
- Pytorch CUDA online 
- Triton

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ X] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
