### PR TITLE
Fix: enable creation of a lb with the same name after deleting the old one

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -779,4 +779,15 @@ class LeaderboardCog(commands.Cog):
                 return
 
         modal = DeleteConfirmationModal("leaderboard", leaderboard_name, self.bot.leaderboard_db)
+
+        forum_channel = self.bot.get_channel(self.bot.leaderboard_forum_id)
+        threads = [thread for thread in forum_channel.threads if thread.name == leaderboard_name]
+
+        if threads:
+            thread = threads[0]
+            new_name = (
+                f"{leaderboard_name} - archived at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+            )
+            await thread.edit(name=new_name, archived=True)
+
         await interaction.response.send_modal(modal)


### PR DESCRIPTION
## Description

Enables creating a leaderboard with the same name after deleting the old one. Issue was caused by the forum channel already existing. Therefore we solve this by renaming the original thread to {original_name} - archived at {timestamp} to avoid having 2 same names.

![image](https://github.com/user-attachments/assets/dfbf486e-99c2-4e8f-93db-af7245d8582b)
![image](https://github.com/user-attachments/assets/1b0d154d-8ed8-413c-a4b6-9ab5a8584721)




## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
