### PR TITLE
WIP: Larger changes to the structure of the eval/reference scripts

### DIFF
--- a/examples/identity_cuda/reference.cuh
+++ b/examples/identity_cuda/reference.cuh
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <array>
+#include <random>
 #include <iostream>
 
 #define N_SIZES 10
@@ -15,13 +16,15 @@ const int Ns[N_SIZES] = {128,  256,  512,   1024,  2048,
 using input_t = std::array<std::vector<float>, N_SIZES>;
 using output_t = input_t;
 
-inline input_t generate_input() {
+inline input_t generate_input(std::mt19937 rng) {
   input_t data;
+
+  std::uniform_real_distribution<float> dist(0, 1);
 
   for (int i = 0; i < N_SIZES; ++i) {
     data[i].resize(Ns[i]);
     for (int j = 0; j < Ns[i]; ++j) {
-      data[i][j] = static_cast<float>(rand()) / RAND_MAX;
+      data[i][j] = dist(rng);
     }
   }
 

--- a/examples/identity_cuda/reference.cuh
+++ b/examples/identity_cuda/reference.cuh
@@ -15,7 +15,7 @@ const int Ns[N_SIZES] = {128,  256,  512,   1024,  2048,
 using input_t = std::array<std::vector<float>, N_SIZES>;
 using output_t = input_t;
 
-input_t generate_input() {
+inline input_t generate_input() {
   input_t data;
 
   for (int i = 0; i < N_SIZES; ++i) {
@@ -29,11 +29,11 @@ input_t generate_input() {
 }
 
 // The identity kernel
-output_t ref_kernel(input_t data) {
+inline output_t ref_kernel(input_t data) {
   return (output_t) data;
 }
 
-bool check_implementation(output_t out, output_t ref, float epsilon = 1e-5) {
+inline bool check_implementation(output_t out, output_t ref, float epsilon = 1e-5) {
   // input_t data = generate_input();
   // output_t reference_out = reference(data);
 

--- a/examples/identity_cuda/reference.cuh
+++ b/examples/identity_cuda/reference.cuh
@@ -33,9 +33,8 @@ inline output_t ref_kernel(input_t data) {
   return (output_t) data;
 }
 
-inline bool check_implementation(output_t out, output_t ref, float epsilon = 1e-5) {
-  // input_t data = generate_input();
-  // output_t reference_out = reference(data);
+inline bool check_implementation(const input_t& data, const output_t& out, float epsilon = 1e-5) {
+  output_t ref = ref_kernel(data);
 
   for (int i = 0; i < N_SIZES; ++i) {
     auto ref_ptr = ref[i];

--- a/examples/thunderkittens_example/reference.cuh
+++ b/examples/thunderkittens_example/reference.cuh
@@ -12,7 +12,7 @@ const int Ns[N_SIZES] = {
 using input_t = std::array<std::vector<float>, N_SIZES>;
 using output_t = input_t;
 
-input_t generate_input() {
+inline input_t generate_input() {
   input_t data;
 
   for (int i = 0; i < N_SIZES; ++i) {
@@ -25,7 +25,7 @@ input_t generate_input() {
   return data;
 }
 
-output_t ref_kernel(input_t data) {
+inline output_t ref_kernel(input_t data) {
   output_t out;
 
   for (int i = 0; i < N_SIZES; ++i) {
@@ -38,7 +38,7 @@ output_t ref_kernel(input_t data) {
   return out;
 }
 
-bool check_implementation(output_t out, output_t ref, float epsilon = 1e-5) {
+inline bool check_implementation(output_t out, output_t ref, float epsilon = 1e-5) {
   // input_t data = generate_input();
   // output_t reference_out = reference(data);
   bool same = true;

--- a/src/discord-cluster-manager/eval.cu
+++ b/src/discord-cluster-manager/eval.cu
@@ -82,8 +82,7 @@ void measure_runtime(PopcornOutput& logger) {
 
         durations.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count());
 
-        auto reference_output = ref_kernel(copy);
-        if (!check_implementation(submission_output, reference_output)) {
+        if (!check_implementation(copy, submission_output)) {
             logger.log("check", "fail");
             std::exit(1);
         }
@@ -128,10 +127,9 @@ int main() {
     }
 
     auto data = generate_input();
-    auto reference_output = ref_kernel(data);
     auto submission_output = custom_kernel(data);
 
-    if (!check_implementation(submission_output, reference_output)) {
+    if (!check_implementation(data, submission_output)) {
         logger.log("check", "fail");
         return 1;
     }

--- a/src/discord-cluster-manager/eval.cu
+++ b/src/discord-cluster-manager/eval.cu
@@ -7,7 +7,9 @@
 #include <memory>
 
 #include "reference.cuh"
-#include "train.cuh"
+
+// forward declarations
+output_t custom_kernel(input_t data);
 
 #define WARMUP_RUNS 10
 #define TIMED_RUNS 100

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -43,22 +43,23 @@ def run_cuda_script(  # # noqa: C901
             ARCH = "-arch=native"
         else:
             ARCH = f"-gencode=arch=compute_{arch},code=sm_{arch}"
-        NVCC_FILES = "eval.cu"
+        NVCC_FILES = ["eval.cu"]
         # Write submission files to directory
         if reference_content is not None:
             with open("reference.cuh", "w") as f:
                 f.write(reference_content)
 
         if submission_content is not None:
-            with open("train.cuh", "w") as f:
+            with open("train.cu", "w") as f:
                 f.write(submission_content)
+            NVCC_FILES += ["train.cu"]
 
         with open("eval.cu", "w") as f:
             f.write(script_content)
 
         execution_start_time = time.perf_counter()
         compile_process = subprocess.run(
-            ["nvcc"] + CUDA_FLAGS + include_dirs + [ARCH, NVCC_FILES, "-o", "eval.out"],
+            ["nvcc"] + CUDA_FLAGS + include_dirs + [ARCH] + NVCC_FILES + ["-o", "eval.out"],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
* Avoid including user code into `eval.cu`. As user code _needs_ to include ` reference.cuh` (at least currently), all functions therein need to be inline to avoid ODR violations.

* call check_implementation with input and output, instead of output and expected output; allows implementations that don't have a  reference kernel, or where validation can be much faster than  running the reference.

* ~~random generators for generate_input~~