### PR TITLE
Fix: wrong function calls to modal runners

### DIFF
--- a/src/discord-cluster-manager/modal_runner_archs.py
+++ b/src/discord-cluster-manager/modal_runner_archs.py
@@ -75,7 +75,7 @@ def run_pytorch_script_l4(
     submission_content: str = None,
     timeout_seconds: int = 600,
 ) -> tuple[str, float]:
-    return modal_run_cuda_script(
+    return modal_run_pytorch_script(
         script_content,
         reference_content,
         submission_content,
@@ -114,7 +114,7 @@ def run_pytorch_script_a100(
     submission_content: str = None,
     timeout_seconds: int = 600,
 ) -> tuple[str, float]:
-    return modal_run_cuda_script(
+    return modal_run_pytorch_script(
         script_content,
         reference_content,
         submission_content,
@@ -153,7 +153,7 @@ def run_pytorch_script_h100(
     submission_content: str = None,
     timeout_seconds: int = 600,
 ) -> tuple[str, float]:
-    return modal_run_cuda_script(
+    return modal_run_pytorch_script(
         script_content,
         reference_content,
         submission_content,


### PR DESCRIPTION
## Description

Small fix that just fixes typos in the modal runners, calling the correct runners based on file type. @ngc92 

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
