### PR TITLE
Add a persistent Leaderboard Channel

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -97,6 +97,7 @@ class ClusterBot(commands.Bot):
         forum_channel = None
         submission_channel = None
         general_channel = None
+        leaderboard_channel = None
         for channel in category.channels:
             if channel.name == "central" and isinstance(channel, discord.ForumChannel):
                 forum_channel = channel
@@ -104,6 +105,8 @@ class ClusterBot(commands.Bot):
                 submission_channel = channel
             elif channel.name == "general" and isinstance(channel, discord.TextChannel):
                 general_channel = channel
+            elif channel.name == "active-leaderboards" and isinstance(channel, discord.TextChannel):
+                leaderboard_channel = channel
 
         if not forum_channel:
             forum_channel = await category.create_forum(
@@ -113,6 +116,19 @@ class ClusterBot(commands.Bot):
         if not general_channel:
             general_channel = await category.create_text_channel(
                 name="general", reason="Created for leaderboard general"
+            )
+
+        if not leaderboard_channel:
+            overwrites = {
+                guild.default_role: discord.PermissionOverwrite(
+                    read_messages=True, send_messages=False
+                ),
+                guild.me: discord.PermissionOverwrite(read_messages=True, send_messages=True),
+            }
+            leaderboard_channel = await category.create_text_channel(
+                name="active-leaderboards",
+                reason="Created for viewing leaderboards",
+                overwrites=overwrites,
             )
 
         if not submission_channel:

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -5,6 +5,7 @@ from io import StringIO
 from typing import List, Optional
 
 import discord
+from discord.ext import commands, tasks
 from consts import (
     AllGPU,
     GitHubGPU,
@@ -62,17 +63,15 @@ class LeaderboardSubmitCog(app_commands.Group):
                 score = float(result.run.result["duration.mean"]) / 1e9
 
                 with self.bot.leaderboard_db as db:
-                    db.create_submission(
-                        {
-                            "submission_name": script.filename,
-                            "submission_time": datetime.now(),
-                            "leaderboard_name": leaderboard_name,
-                            "code": submission_content,
-                            "user_id": interaction.user.id,
-                            "submission_score": score,
-                            "gpu_type": gpu.name,
-                        }
-                    )
+                    db.create_submission({
+                        "submission_name": script.filename,
+                        "submission_time": datetime.now(),
+                        "leaderboard_name": leaderboard_name,
+                        "code": submission_content,
+                        "user_id": interaction.user.id,
+                        "submission_score": score,
+                        "gpu_type": gpu.name,
+                    })
 
                 user_id = (
                     interaction.user.global_name
@@ -336,9 +335,48 @@ class LeaderboardCog(commands.Cog):
             name="eval-code", description="Get leaderboard evaluation codes"
         )(self.get_leaderboard_eval)
 
+        # Start updating leaderboard
+        self.leaderboard_update.start()
+
+    # --------------------------------------------------------------------------
+    # |                           LOOPING FUNCTIONS                            |
+    # --------------------------------------------------------------------------
+    @tasks.loop(minutes=1)
+    async def leaderboard_update(self):
+        """Task that updates the leaderboard every minute."""
+        for guild in self.bot.guilds:
+            channel = await self.ensure_channel_exists(guild, "active-leaderboards")
+
+            # Get the pinned message or create a new one
+            pinned_messages = await channel.pins()
+            if pinned_messages:
+                message = pinned_messages[0]
+            else:
+                message = await channel.send("Loading leaderboard...")
+                await message.pin()
+
+            # Update the leaderboard message
+            embed, view = await self._get_leaderboard_helper()
+
+            if embed:
+                await message.edit(content="", embed=embed, view=view)
+            else:
+                await message.edit(content="No active leaderboards.")
+
+    @leaderboard_update.before_loop
+    async def before_leaderboard_update(self):
+        """Wait for the bot to be ready before starting the task."""
+        await self.bot.wait_until_ready()
+
     # --------------------------------------------------------------------------
     # |                           HELPER FUNCTIONS                              |
     # --------------------------------------------------------------------------
+    async def ensure_channel_exists(self, guild, channel_name):
+        """Ensure the leaderboard channel exists, and create it if not."""
+        channel = discord.utils.get(guild.text_channels, name=channel_name)
+        if not channel:
+            channel = await guild.create_text_channel(channel_name)
+        return channel
 
     async def admin_check(self, interaction: discord.Interaction) -> bool:
         if not interaction.user.get_role(self.bot.leaderboard_admin_role_id):
@@ -479,20 +517,16 @@ class LeaderboardCog(commands.Cog):
                     interaction, "An unknown error occurred.", ephemeral=True
                 )
 
-    # --------------------------------------------------------------------------
-    # |                           COMMANDS                                      |
-    # --------------------------------------------------------------------------
-
-    async def get_leaderboards(self, interaction: discord.Interaction):
-        """Display all leaderboards in a table format"""
-        await interaction.response.defer(ephemeral=True)
-
+    async def _get_leaderboard_helper(self):
+        """
+        Helper for grabbing the leaderboard DB and forming the
+        renderable item.
+        """
         with self.bot.leaderboard_db as db:
             leaderboards = db.get_leaderboards()
 
         if not leaderboards:
-            await send_discord_message(interaction, "No leaderboards found.", ephemeral=True)
-            return
+            return None, None
 
         to_show = [
             {
@@ -514,6 +548,22 @@ class LeaderboardCog(commands.Cog):
             items_per_page=5,
             column_widths=column_widths,
         )
+
+        return embed, view
+
+    # --------------------------------------------------------------------------
+    # |                           COMMANDS                                      |
+    # --------------------------------------------------------------------------
+
+    async def get_leaderboards(self, interaction: discord.Interaction):
+        """Display all leaderboards in a table format"""
+        await interaction.response.defer(ephemeral=True)
+
+        embed, view = await self._get_leaderboard_helper()
+
+        if not embed:
+            await send_discord_message(interaction, "No leaderboards found.", ephemeral=True)
+            return
 
         await send_discord_message(
             interaction,
@@ -608,7 +658,6 @@ class LeaderboardCog(commands.Cog):
             return
 
         # Try parsing with time first
-        # Try parsing with time first
         try:
             date_value = datetime.strptime(deadline, "%Y-%m-%d %H:%M")
         except ValueError:
@@ -640,15 +689,13 @@ class LeaderboardCog(commands.Cog):
             template_content = await reference_code.read()
 
             with self.bot.leaderboard_db as db:
-                err = db.create_leaderboard(
-                    {
-                        "name": leaderboard_name,
-                        "deadline": date_value,
-                        "reference_code": template_content.decode("utf-8"),
-                        "gpu_types": view.selected_gpus,
-                        "creator_id": interaction.user.id,
-                    }
-                )
+                err = db.create_leaderboard({
+                    "name": leaderboard_name,
+                    "deadline": date_value,
+                    "reference_code": template_content.decode("utf-8"),
+                    "gpu_types": view.selected_gpus,
+                    "creator_id": interaction.user.id,
+                })
 
                 if err:
                     if "duplicate key" in err:

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -5,14 +5,13 @@ from io import StringIO
 from typing import List, Optional
 
 import discord
-from discord.ext import commands, tasks
 from consts import (
     AllGPU,
     GitHubGPU,
     ModalGPU,
 )
 from discord import app_commands
-from discord.ext import commands
+from discord.ext import commands, tasks
 from leaderboard_db import leaderboard_name_autocomplete
 from leaderboard_eval import cu_eval, py_eval
 from ui.misc import DeleteConfirmationModal, GPUSelectionView


### PR DESCRIPTION
## Description

Add a channel that just displays the leaderboard. Had to also split up cog functionality from forming the leaderboard to get this to work (you can't just call slash commands internally).

The read-only channel looks like so: It just repeatedly edits the same message (or adds an initial one) with an updated LB.

<img width="680" alt="Screenshot 2025-01-17 at 3 51 41 PM" src="https://github.com/user-attachments/assets/aedd3df4-f064-4b80-a4ce-e34946f82b33" />

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
