### PR TITLE
small fixes of problems encoutered during development

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -79,7 +79,7 @@ class ClusterBot(commands.Bot):
                 commands = await self.tree.fetch_commands(guild=guild)
                 logger.info(f"Synced commands: {[cmd.name for cmd in commands]}")
         except Exception as e:
-            logger.error(f"Failed to sync commands: {e}")
+            logger.error(f"Failed to sync commands: {e}", exc_info=e)
 
     async def _setup_leaderboards(self):  # noqa: C901
         assert len(self.guilds) == 1, "Bot must be in only one guild"

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -87,7 +87,8 @@ class LeaderboardSubmitCog(app_commands.Group):
                     + f"Submission user: {user_id}.\n"
                     + f"Runtime: {score:.9f} seconds.",
                 )
-        except Exception:
+        except Exception as e:
+            logger.error("Error in leaderboard submission", exc_info=e)
             await discord_thread.send(
                 f"Leaderboard submission to '{leaderboard_name}' on {gpu.name} "
                 + f"using {runner_name} runners failed!\n",
@@ -467,7 +468,7 @@ class LeaderboardCog(commands.Cog):
                 )
 
         except Exception as e:
-            logger.error(str(e))
+            logger.error(str(e), exc_info=e)
             if "'NoneType' object is not subscriptable" in str(e):
                 await send_discord_message(
                     interaction,
@@ -708,7 +709,7 @@ class LeaderboardCog(commands.Cog):
                 ephemeral=True,
             )
         except Exception as e:
-            logger.error(f"Error in leaderboard creation: {e}")
+            logger.error(f"Error in leaderboard creation: {e}", exc_info=e)
             # Handle any other errors
             await send_discord_message(
                 interaction,

--- a/src/discord-cluster-manager/cogs/misc_cog.py
+++ b/src/discord-cluster-manager/cogs/misc_cog.py
@@ -19,6 +19,8 @@ class BotManagerCog(commands.Cog):
 
     @app_commands.command(name="resync")
     async def resync(self, interaction: discord.Interaction):
+        logger.info("Resyncing commands")
+
         """Admin command to resync slash commands"""
         if interaction.user.guild_permissions.administrator:
             try:
@@ -27,13 +29,13 @@ class BotManagerCog(commands.Cog):
                 self.bot.tree.clear_commands(guild=interaction.guild)
                 await self.bot.tree.sync(guild=interaction.guild)
                 commands = await self.bot.tree.fetch_commands(guild=interaction.guild)
-                send_discord_message(
+                await send_discord_message(
                     interaction,
                     "Resynced commands:\n" + "\n".join([f"- /{cmd.name}" for cmd in commands]),
                 )
             except Exception as e:
                 logger.error(f"Error in resync command: {str(e)}", exc_info=True)
-                send_discord_message(interaction, f"Error: {str(e)}")
+                await send_discord_message(interaction, f"Error: {str(e)}")
         else:
             await send_discord_message(
                 interaction, "You need administrator permissions to use this command"

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -61,13 +61,7 @@ class VerifyRunCog(commands.Cog):
 
         message_contents = [msg.content async for msg in github_thread.history(limit=None)]
 
-        required_patterns = [
-            "Processing `.*` with",
-            "GitHub Action triggered! Run ID:",
-            "Training completed with status: success",
-            "'check': 'pass'",
-            "View the full run at:",
-        ]
+        required_patterns = ["Processing `.*` with", "Running on GitHub...", "'check': 'pass'"]
 
         all_patterns_found = all(
             any(re.search(pattern, content, re.DOTALL) is not None for content in message_contents)

--- a/src/discord-cluster-manager/github_runner.py
+++ b/src/discord-cluster-manager/github_runner.py
@@ -1,0 +1,156 @@
+import asyncio
+import pprint
+import tempfile
+import zipfile
+from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, Optional
+
+import requests
+from env import GITHUB_REPO, GITHUB_TOKEN
+from github import Github, UnknownObjectException, WorkflowRun
+from utils import get_github_branch_name, setup_logging
+
+logger = setup_logging()
+
+
+class GitHubRun:
+    def __init__(self, workflow_file: str):
+        gh = Github(GITHUB_TOKEN)
+        self.repo = gh.get_repo(GITHUB_REPO)
+        self.workflow_file = workflow_file
+        self.run: Optional[WorkflowRun.WorkflowRun] = None
+        self.start_time = None
+
+    @property
+    def run_id(self):
+        if self.run is None:
+            return None
+        return self.run.id
+
+    @property
+    def html_url(self):
+        if self.run is None:
+            return None
+        return self.run.html_url
+
+    @property
+    def status(self):
+        if self.run is None:
+            return None
+        return self.run.status
+
+    @property
+    def elapsed_time(self):
+        if self.start_time is None:
+            return None
+        return datetime.now(timezone.utc) - self.start_time
+
+    async def trigger(self, inputs: dict) -> bool:
+        """
+        Trigger this run with the provided inputs.
+        Sets `self.run` to the new WorkflowRun on success.
+
+        Returns: Whether the run was successfully triggered,
+        """
+        trigger_time = datetime.now(timezone.utc)
+        try:
+            workflow = self.repo.get_workflow(self.workflow_file)
+        except UnknownObjectException as e:
+            logger.error(f"Could not find workflow {self.workflow_file}", exc_info=e)
+            raise ValueError(f"Could not find workflow {self.workflow_file}") from e
+
+        logger.debug(
+            "Dispatching workflow %s on branch %s with inputs %s",
+            self.workflow_file,
+            get_github_branch_name(),
+            pprint.pformat(inputs),
+        )
+        success = workflow.create_dispatch(get_github_branch_name(), inputs=inputs)
+        if success:
+            await asyncio.sleep(2)
+            runs = list(workflow.get_runs())
+
+            for run in runs:
+                if run.created_at.replace(tzinfo=timezone.utc) > trigger_time:
+                    self.run = run
+                    return True
+        return False
+
+    async def wait_for_completion(
+        self, callback: Callable[["GitHubRun"], Awaitable[None]], timeout_minutes: int = 5
+    ):
+        if self.run is None:
+            raise ValueError("Run needs to be triggered before a status check!")
+
+        self.start_time = datetime.now(timezone.utc)
+        timeout = timedelta(minutes=timeout_minutes)
+
+        while True:
+            try:
+                # update run status
+                self.run = run = self.repo.get_workflow_run(self.run_id)
+
+                if self.elapsed_time > timeout:
+                    try:
+                        self.run.cancel()
+                        # Wait briefly to ensure cancellation is processed
+                        # And Verify the run was actually cancelled
+                        await asyncio.sleep(5)
+                        run = self.repo.get_workflow_run(self.run_id)
+                        if run.status != "completed":
+                            logger.warning(f"Failed to cancel workflow run {self.run_id}")
+                    except Exception as e:
+                        logger.error(f"Error cancelling workflow: {str(e)}", exc_info=e)
+                        raise
+
+                    logger.warning(
+                        f"Workflow {self.run_id} cancelled - "
+                        f"exceeded {timeout_minutes} minute timeout"
+                    )
+                    raise TimeoutError(
+                        f"Workflow {self.run_id} cancelled - "
+                        f"exceeded {timeout_minutes} minute timeout"
+                    )
+
+                if run.status == "completed":
+                    return
+
+                await callback(self)
+                await asyncio.sleep(20)
+            except TimeoutError:
+                raise
+            except Exception as e:
+                logger.error(f"Error waiting for GitHub run {self.run_id}: {e}", exc_info=e)
+                raise
+
+    async def download_artifacts(self) -> dict:
+        logger.info("Attempting to download artifacts for run %s", self.run_id)
+        artifacts = self.run.get_artifacts()
+
+        extracted = {}
+
+        for artifact in artifacts:
+            url = artifact.archive_download_url
+            headers = {"Authorization": f"token {GITHUB_TOKEN}"}
+            response = requests.get(url, headers=headers)
+
+            if response.status_code == 200:
+                with tempfile.NamedTemporaryFile("w+b") as temp:
+                    temp.write(response.content)
+                    temp.flush()
+
+                    with zipfile.ZipFile(temp.name) as z:
+                        artifact_dict = {}
+                        for file in z.namelist():
+                            with z.open(file) as f:
+                                artifact_dict[file] = f.read()
+
+                extracted[artifact.name] = artifact_dict
+            else:
+                raise RuntimeError(
+                    f"Failed to download artifact {artifact.name}. "
+                    f"Status code: {response.status_code}"
+                )
+
+        logger.info("Download artifacts for run %s: %s", self.run_id, list(extracted.keys()))
+        return extracted


### PR DESCRIPTION
When logging with `logger.error`, we want to include the exception info, so that the cause can be identified in the traceback.
also found two missing `await` statements.

This is based on top of #137 