### PR TITLE
bugfix

### DIFF
--- a/src/discord-cluster-manager/report.py
+++ b/src/discord-cluster-manager/report.py
@@ -29,9 +29,12 @@ async def _send_split_log(thread: discord.Thread, partial_message: str, header: 
                 chunks.append(partial_message)
                 partial_message = line
 
+        if partial_message != "":
+            chunks.append(partial_message)
+
         # now, format the chunks
         for i, chunk in enumerate(chunks):
-            partial_message += f"\n\n## {header} ({i}/{len(chunks)}):\n"
+            partial_message += f"\n\n## {header} ({i+1}/{len(chunks)}):\n"
             partial_message += f"```\n{_limit_length(chunk, 1900)}```"
             await thread.send(partial_message)
 


### PR DESCRIPTION
fixes two major errors in the split log function:
1) the last chunk wasn't added
2) partial message wasn't reset after sending.

i'm not sure if, in the long run, this is actually what we want to go with. Probably, for long stdout/stderr logs, we'd just put them as attachments. For now, though, this helps in debugging things.