### PR TITLE
Task definitions as json strings

### DIFF
--- a/examples/identity_cuda/eval.cu
+++ b/examples/identity_cuda/eval.cu
@@ -1,0 +1,149 @@
+#include <chrono>
+#include <iostream>
+#include <cstdint>
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include <memory>
+
+#include "reference.cuh"
+#include "submission.cuh"
+
+#define WARMUP_RUNS 10
+#define TIMED_RUNS 100
+
+struct Closer {
+    void operator()(std::FILE* file) {
+        std::fclose(file);
+    }
+};
+
+struct PopcornOutput {
+    template<class... Args>
+    void printf(Args&&... args) {
+        ::fprintf(File.get(), std::forward<Args>(args)...);
+    }
+
+    void log(const char* key, const char* value) {
+        printf("%s: %s\n", key, value);
+    }
+
+    template<class T>
+    void log(const char* key, T&& value) {
+        log(key, std::to_string(value).c_str());
+    }
+
+    std::unique_ptr<std::FILE, Closer> File;
+};
+
+// checks that a CUDA API call returned successfully, otherwise prints an error message and exits.
+static void cuda_check(cudaError_t status, const char* expr, const char* file, int line, const char* function)
+{
+    if(status != cudaSuccess) {
+        std::cerr << "CUDA error (" << (int)status << ") while evaluating expression "
+                  << expr << " at "
+                  << file << '('
+                  << line << ") in `"
+                  << function << "`: "
+                  << cudaGetErrorString(status) << std::endl;
+        std::exit(110);
+    }
+}
+
+#define cuda_check(expr) cuda_check(expr, #expr, __FILE__, __LINE__, __FUNCTION__)
+
+void measure_runtime(PopcornOutput& logger, std::mt19937& rng) {
+    std::cout << "warming up..." << std::endl;
+
+    {
+        auto warmup_data = generate_input(rng());
+        for (int i = 0; i < WARMUP_RUNS; i++) {
+            // discard result; this is just warmup, we don't care what it returns
+            (void)custom_kernel(warmup_data);
+            cuda_check(cudaDeviceSynchronize());
+        }
+    }
+
+    std::vector<std::int64_t> durations;
+    durations.reserve(TIMED_RUNS);
+
+    for (int i = 0; i < TIMED_RUNS; i++) {
+        auto data = generate_input(rng());
+
+        // make a copy of the input data to be used by the reference implementation
+        auto copy = data;
+
+        auto start = std::chrono::high_resolution_clock::now();
+        // move data into custom_kernel, so that if custom_kernel takes large std::vectors or similar by value,
+        // we're not measuring the copy overhead.
+        auto submission_output = custom_kernel(std::move(data));
+        cuda_check(cudaDeviceSynchronize());
+        auto end = std::chrono::high_resolution_clock::now();
+
+        durations.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count());
+
+        auto reference_output = ref_kernel(copy);
+        if (!check_implementation(submission_output, reference_output)) {
+            logger.log("check", "fail");
+            std::exit(112);
+        }
+
+    }
+
+    // calculate duration statistics
+    std::int64_t total_duration = std::accumulate(durations.begin(), durations.end(), (std::int64_t)0);
+    std::int64_t best = *std::min_element(durations.begin(), durations.end());
+    std::int64_t worst = *std::max_element(durations.begin(), durations.end());
+    double average_duration = (double)total_duration / TIMED_RUNS;
+
+    double variance = 0.0;
+    for(auto d : durations) {
+        variance += std::pow((double)d - average_duration, 2);
+    }
+
+    // sample standard deviation with Bessel's correction
+    double standard_deviation = std::sqrt(variance / (TIMED_RUNS - 1));
+    // standard error of the mean
+    double standard_error = standard_deviation / std::sqrt(TIMED_RUNS);
+
+    logger.log("check", "pass");
+    logger.log("duration.mean", average_duration);
+    logger.log("duration.std", standard_deviation);
+    logger.log("duration.err", standard_error);
+    logger.log("duration.best", best);
+    logger.log("duration.worst", worst);
+
+
+    std::cout << "average kernel runtime: " << average_duration / 1e6 << " ± " << standard_error / 1e6 << " µs" << std::endl;
+}
+
+int main() {
+    const char *output_fd = std::getenv("POPCORN_FD");
+    PopcornOutput logger;
+    if (output_fd) {
+        int fd = std::stoi(output_fd);
+        logger.File.reset(::fdopen(fd, "w"));
+    } else {
+        return 111;
+    }
+
+    // get the seed
+    const char *seed_str = std::getenv("POPCORN_SEED");
+    int seed = 42;
+    if (seed_str) {
+        seed = std::stoi(output_fd);
+    }
+
+    std::mt19937 rng(seed);
+    auto data = generate_input(rng());
+    auto reference_output = ref_kernel(data);
+    auto submission_output = custom_kernel(data);
+
+    if (!check_implementation(submission_output, reference_output)) {
+        logger.log("check", "fail");
+        return 112;
+    }
+
+    measure_runtime(logger, rng);
+    return 0;
+}

--- a/examples/identity_cuda/reference.cuh
+++ b/examples/identity_cuda/reference.cuh
@@ -9,14 +9,9 @@
 #include <random>
 #include <iostream>
 
-#define N_SIZES 10
-const int Ns[N_SIZES] = {128,  256,  512,   1024,  2048,
-                         4096, 8192, 16384, 32768, 65536};
+#include "task.h"
 
-using input_t = std::array<std::vector<float>, N_SIZES>;
-using output_t = input_t;
-
-input_t generate_input(int seed) {
+static input_t generate_input(int seed) {
   std::mt19937 rng(seed);
   input_t data;
 
@@ -33,11 +28,11 @@ input_t generate_input(int seed) {
 }
 
 // The identity kernel
-output_t ref_kernel(input_t data) {
+static output_t ref_kernel(input_t data) {
   return (output_t) data;
 }
 
-bool check_implementation(output_t out, output_t ref, float epsilon = 1e-5) {
+static bool check_implementation(output_t out, output_t ref, float epsilon = 1e-5) {
   // input_t data = generate_input();
   // output_t reference_out = reference(data);
 

--- a/examples/identity_cuda/submission.cu
+++ b/examples/identity_cuda/submission.cu
@@ -1,6 +1,7 @@
 #include <array>
 #include <vector>
-#include "reference.cuh"
+#include "task.h"
+#include "utils.h"
 
 __global__ void copy_kernel(float *input, float *output, int N)
 {
@@ -22,11 +23,11 @@ output_t custom_kernel(input_t data)
 
         // Allocate device memory
         float *d_input, *d_output;
-        cudaMalloc(&d_input, N * sizeof(float));
-        cudaMalloc(&d_output, N * sizeof(float));
+        CUDA_CHECK(cudaMalloc(&d_input, N * sizeof(float)));
+        CUDA_CHECK(cudaMalloc(&d_output, N * sizeof(float)));
 
         // Copy input to device
-        cudaMemcpy(d_input, data[i].data(), N * sizeof(float), cudaMemcpyHostToDevice);
+        CUDA_CHECK(cudaMemcpy(d_input, data[i].data(), N * sizeof(float), cudaMemcpyHostToDevice));
 
         // Launch kernel
         int blockSize = 256;
@@ -34,11 +35,11 @@ output_t custom_kernel(input_t data)
         copy_kernel<<<numBlocks, blockSize>>>(d_input, d_output, N);
 
         // Copy result back to host
-        cudaMemcpy(result[i].data(), d_output, N * sizeof(float), cudaMemcpyDeviceToHost);
+        CUDA_CHECK(cudaMemcpy(result[i].data(), d_output, N * sizeof(float), cudaMemcpyDeviceToHost));
 
         // Free device memory
-        cudaFree(d_input);
-        cudaFree(d_output);
+        CUDA_CHECK(cudaFree(d_input));
+        CUDA_CHECK(cudaFree(d_output));
     }
 
     return result;

--- a/examples/identity_cuda/task.h
+++ b/examples/identity_cuda/task.h
@@ -1,0 +1,14 @@
+#ifndef __TASK_H__
+#define __TASK_H__
+
+#include <vector>
+#include <array>
+
+#define N_SIZES 10
+const int Ns[N_SIZES] = {128,  256,  512,   1024,  2048,
+                         4096, 8192, 16384, 32768, 65536};
+
+using input_t = std::array<std::vector<float>, N_SIZES>;
+using output_t = input_t;
+
+#endif

--- a/examples/identity_cuda/task.yml
+++ b/examples/identity_cuda/task.yml
@@ -4,16 +4,21 @@
 # these files will be baked into the json object, so that they are available during testing
 files:
   - {"name": "eval.cu", "source": "eval.cu"}
+  - {"name": "task.h", "source": "task.h"}
+  - {"name": "utils.h", "source": "utils.h"}
   - {"name": "reference.cuh", "source": "reference.cuh"}
-  - {"name": "submission.cuh", "source": "@SUBMISSION@"}
+  - {"name": "submission.cu", "source": "@SUBMISSION@"}
 
 # task language, depending on this we do get different keys in runner
 lang: "cu"
 
+description:
+  A simple test task
+
 # Config object
 config:
   # task provided source files to compile
-  sources: ["eval.cu"]
+  sources: ["eval.cu", "submission.cu"]
 
   # additional include directories
   include_dirs: []

--- a/examples/identity_cuda/task.yml
+++ b/examples/identity_cuda/task.yml
@@ -3,7 +3,7 @@
 
 # these files will be baked into the json object, so that they are available during testing
 files:
-  - {"name": "eval.cu", "source": "@EVAL_CU@"}
+  - {"name": "eval.cu", "source": "eval.cu"}
   - {"name": "reference.cuh", "source": "reference.cuh"}
   - {"name": "submission.cuh", "source": "@SUBMISSION@"}
 

--- a/examples/identity_cuda/task.yml
+++ b/examples/identity_cuda/task.yml
@@ -1,0 +1,19 @@
+# name of the task
+# name: identity-cuda
+
+# these files will be baked into the json object, so that they are available during testing
+files:
+  - {"name": "eval.cu", "source": "@EVAL_CU@"}
+  - {"name": "reference.cuh", "source": "reference.cuh"}
+  - {"name": "submission.cuh", "source": "@SUBMISSION@"}
+
+# task language, depending on this we do get different keys in runner
+lang: "cu"
+
+# Config object
+config:
+  # task provided source files to compile
+  sources: ["eval.cu"]
+
+  # additional include directories
+  include_dirs: []

--- a/examples/identity_cuda/utils.h
+++ b/examples/identity_cuda/utils.h
@@ -1,0 +1,24 @@
+#ifndef POPCORN_UTILS_H
+#define POPCORN_UTILS_H
+
+#include <iostream>
+
+// checks that a CUDA API call returned successfully, otherwise prints an error message and exits.
+static inline void cuda_check_(cudaError_t status, const char* expr, const char* file, int line, const char* function)
+{
+    if(status != cudaSuccess) {
+        std::cerr << "CUDA error (" << (int)status << ") while evaluating expression "
+                  << expr << " at "
+                  << file << '('
+                  << line << ") in `"
+                  << function << "`: "
+                  << cudaGetErrorString(status) << std::endl;
+        std::exit(110);
+    }
+}
+
+// Convenience macro, automatically logs expression, file, line, and function name
+// of the error.
+#define CUDA_CHECK(expr) cuda_check_(expr, #expr, __FILE__, __LINE__, __FUNCTION__)
+
+#endif

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -14,7 +14,7 @@ from consts import (
 from discord import app_commands
 from discord.ext import commands, tasks
 from leaderboard_db import leaderboard_name_autocomplete
-from leaderboard_eval import cu_eval, py_eval
+from task import LeaderboardTask
 from ui.misc import DeleteConfirmationModal, GPUSelectionView
 from ui.table import create_table
 from utils import (
@@ -37,7 +37,7 @@ class LeaderboardSubmitCog(app_commands.Group):
         leaderboard_name: str,
         script: discord.Attachment,
         command: Callable,
-        reference_code,
+        task: LeaderboardTask,
         submission_content,
         cog: commands.Cog,
         gpu: AllGPU,
@@ -51,7 +51,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                     name=gpu.name,
                     value=gpu.value,
                 ),
-                reference_code=reference_code,
+                task=task,
             )
         except discord.errors.NotFound as e:
             print(f"Webhook not found: {e}")
@@ -62,15 +62,17 @@ class LeaderboardSubmitCog(app_commands.Group):
                 score = float(result.run.result["duration.mean"]) / 1e9
 
                 with self.bot.leaderboard_db as db:
-                    db.create_submission({
-                        "submission_name": script.filename,
-                        "submission_time": datetime.now(),
-                        "leaderboard_name": leaderboard_name,
-                        "code": submission_content,
-                        "user_id": interaction.user.id,
-                        "submission_score": score,
-                        "gpu_type": gpu.name,
-                    })
+                    db.create_submission(
+                        {
+                            "submission_name": script.filename,
+                            "submission_time": datetime.now(),
+                            "leaderboard_name": leaderboard_name,
+                            "code": submission_content,
+                            "user_id": interaction.user.id,
+                            "submission_score": score,
+                            "gpu_type": gpu.name,
+                        }
+                    )
 
                 user_id = (
                     interaction.user.global_name
@@ -127,7 +129,6 @@ class LeaderboardSubmitCog(app_commands.Group):
         sure reference code, deadlines, etc. are all correct.
         """
         # Read and convert reference code
-        reference_code = None
         with self.bot.leaderboard_db as db:
             leaderboard_item = db.get_leaderboard(leaderboard_name)
 
@@ -150,9 +151,8 @@ class LeaderboardSubmitCog(app_commands.Group):
                 )
                 return None
 
-            leaderboard_item = db.get_leaderboard(leaderboard_name)
             gpus = db.get_leaderboard_gpu_types(leaderboard_name)
-            reference_code = leaderboard_item["reference_code"]
+            task = leaderboard_item["task"]
 
         # Read the template file
         submission_content = await script.read()
@@ -165,7 +165,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             )
             return None
 
-        return (submission_content, reference_code, gpus)
+        return submission_content, task, gpus
 
     async def on_submit_hook(
         self,
@@ -181,7 +181,7 @@ class LeaderboardSubmitCog(app_commands.Group):
         Called as the main body of a submission to route to the correct runner.
         """
         try:
-            submission_content, reference_code, gpus = await self.before_submit_hook(
+            submission_content, task, gpus = await self.before_submit_hook(
                 interaction,
                 leaderboard_name,
                 script,
@@ -209,7 +209,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 leaderboard_name,
                 script,
                 command,
-                reference_code,
+                task,
                 submission_content,
                 cog,
                 AllGPU[gpu],
@@ -310,13 +310,9 @@ class LeaderboardCog(commands.Cog):
             name="show-personal", description="Get all your submissions for a leaderboard"
         )(self.get_user_leaderboard_submissions)
 
-        self.get_leaderboard_references = bot.leaderboard_group.command(
-            name="reference-code", description="Get leaderboard reference codes"
-        )(self.get_leaderboard_references)
-
-        self.get_leaderboard_eval = bot.leaderboard_group.command(
-            name="eval-code", description="Get leaderboard evaluation codes"
-        )(self.get_leaderboard_eval)
+        self.get_leaderboard_task = bot.leaderboard_group.command(
+            name="task", description="Get leaderboard reference codes"
+        )(self.get_leaderboard_task)
 
         # Start updating leaderboard
         self.leaderboard_update.start()
@@ -558,56 +554,24 @@ class LeaderboardCog(commands.Cog):
 
     @app_commands.describe(leaderboard_name="Name of the leaderboard")
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
-    async def get_leaderboard_references(
-        self, interaction: discord.Interaction, leaderboard_name: str
-    ):
+    async def get_leaderboard_task(self, interaction: discord.Interaction, leaderboard_name: str):
         await interaction.response.defer(ephemeral=True)
 
         with self.bot.leaderboard_db as db:
-            leaderboard_item = db.get_leaderboard(leaderboard_name)
+            leaderboard_item = db.get_leaderboard(leaderboard_name)  # type: LeaderboardItem
             if not leaderboard_item:
                 await send_discord_message(interaction, "Leaderboard not found.", ephemeral=True)
                 return
 
-        code = leaderboard_item["reference_code"]
-        code_file = StringIO(code)
-        language = "cuda" if "#include" in code else "python"
-        suffix = "py" if language == "python" else "cuh"
+        code = leaderboard_item["task"].files
 
-        ref_code = discord.File(
-            fp=code_file, filename=f"{leaderboard_name}_reference_code.{suffix}"
-        )
+        files = []
+        for file_name, content in code.items():
+            files.append(discord.File(fp=StringIO(content), filename=file_name))
 
-        message = (
-            f"**Reference Code for {leaderboard_name} in {language}**\n"
-            f"*If you want to display the evaluation code, run `/leaderboard eval-code {language}`*"
-        )
+        message = f"**Reference Code for {leaderboard_name}**\n"
 
-        await send_discord_message(interaction, message, ephemeral=True, file=ref_code)
-
-    @app_commands.describe(language="Language of the evaluation code [cpp, python]")
-    @app_commands.choices(
-        language=[app_commands.Choice(name=lang, value=lang) for lang in ["cuda", "python"]]
-    )
-    async def get_leaderboard_eval(self, interaction: discord.Interaction, language: str):
-        await interaction.response.defer(ephemeral=True)
-
-        if language == "cuda":
-            eval_code = cu_eval
-        else:
-            eval_code = py_eval
-
-        suffix = "py" if language == "python" else "cu"
-
-        code_file = StringIO(eval_code)
-        ref_code = discord.File(fp=code_file, filename=f"leaderboard_eval.{suffix}")
-
-        await send_discord_message(
-            interaction,
-            f"**Evaluation Code for language: {language}**\n",
-            file=ref_code,
-            ephemeral=True,
-        )
+        await send_discord_message(interaction, message, ephemeral=True, files=files)
 
     @discord.app_commands.describe(
         leaderboard_name="Name of the leaderboard",
@@ -669,16 +633,19 @@ class LeaderboardCog(commands.Cog):
 
         try:
             # Read the template file
-            template_content = await reference_code.read()
+            task_str = (await reference_code.read()).decode("utf-8")
+            task = LeaderboardTask.from_str(task_str)
 
             with self.bot.leaderboard_db as db:
-                err = db.create_leaderboard({
-                    "name": leaderboard_name,
-                    "deadline": date_value,
-                    "reference_code": template_content.decode("utf-8"),
-                    "gpu_types": view.selected_gpus,
-                    "creator_id": interaction.user.id,
-                })
+                err = db.create_leaderboard(
+                    {
+                        "name": leaderboard_name,
+                        "deadline": date_value,
+                        "task": task,
+                        "gpu_types": view.selected_gpus,
+                        "creator_id": interaction.user.id,
+                    }
+                )
 
                 if err:
                     if "duplicate key" in err:

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -1,7 +1,9 @@
 import asyncio
-from datetime import datetime
+import os
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from io import StringIO
+from pathlib import Path
 from typing import Callable, List, Optional
 
 import discord
@@ -14,7 +16,7 @@ from consts import (
 from discord import app_commands
 from discord.ext import commands, tasks
 from leaderboard_db import leaderboard_name_autocomplete
-from task import LeaderboardTask
+from task import LeaderboardTask, make_task
 from ui.misc import DeleteConfirmationModal, GPUSelectionView
 from ui.table import create_table
 from utils import (
@@ -298,6 +300,10 @@ class LeaderboardCog(commands.Cog):
             name="create", description="Create a new leaderboard"
         )(self.leaderboard_create)
 
+        self.leaderboard_create_local = bot.leaderboard_group.command(
+            name="create-local", description="Create or update a leaderboard from a local directory"
+        )(self.leaderboard_create_local)
+
         self.delete_leaderboard = bot.leaderboard_group.command(
             name="delete", description="Delete a leaderboard"
         )(self.delete_leaderboard)
@@ -575,6 +581,49 @@ class LeaderboardCog(commands.Cog):
 
     @discord.app_commands.describe(
         leaderboard_name="Name of the leaderboard",
+        directory="Directory of the kernel definition",
+    )
+    async def leaderboard_create_local(
+        self,
+        interaction: discord.Interaction,
+        leaderboard_name: str,
+        directory: str,
+    ):
+        is_admin = await self.admin_check(interaction)
+        if not is_admin:
+            await send_discord_message(
+                interaction,
+                "Debug command, only for admins.",
+                ephemeral=True,
+            )
+            return
+
+        old_cwd = Path.cwd()
+        try:
+            assert Path(directory).resolve().is_relative_to(Path.cwd())
+            os.chdir(directory)
+            task = make_task("task.yml")
+        finally:
+            os.chdir(old_cwd)
+
+        # create-local overwrites existing leaderboard
+        with self.bot.leaderboard_db as db:
+            db.delete_leaderboard(leaderboard_name)
+
+        await self.create_leaderboard_in_db(
+            interaction,
+            leaderboard_name,
+            datetime.now(timezone.utc) + timedelta(days=365),
+            task=task,
+        )
+
+        await send_discord_message(
+            interaction,
+            f"Leaderboard '{leaderboard_name}' created.",
+        )
+
+    @discord.app_commands.describe(
+        leaderboard_name="Name of the leaderboard",
         deadline="Competition deadline in the form: 'Y-m-d'",
         reference_code="Reference implementation of kernel. Also includes eval code.",
     )
@@ -619,51 +668,16 @@ class LeaderboardCog(commands.Cog):
                 )
                 return
 
-        # Ask the user to select GPUs
-        view = GPUSelectionView([gpu.name for gpu in GitHubGPU] + [gpu.name for gpu in ModalGPU])
-
-        await send_discord_message(
-            interaction,
-            "Please select GPUs for this leaderboard.",
-            view=view,
-            ephemeral=True,
-        )
-
-        await view.wait()
-
         try:
             # Read the template file
             task_str = (await reference_code.read()).decode("utf-8")
             task = LeaderboardTask.from_str(task_str)
 
-            with self.bot.leaderboard_db as db:
-                err = db.create_leaderboard(
-                    {
-                        "name": leaderboard_name,
-                        "deadline": date_value,
-                        "task": task,
-                        "gpu_types": view.selected_gpus,
-                        "creator_id": interaction.user.id,
-                    }
-                )
-
-                if err:
-                    if "duplicate key" in err:
-                        await send_discord_message(
-                            interaction,
-                            "Error: Tried to create a leaderboard "
-                            f'"{leaderboard_name}" that already exists.',
-                            ephemeral=True,
-                        )
-                    else:
-                        # Handle any other errors
-                        logger.error(f"Error in leaderboard creation: {err}")
-                        await send_discord_message(
-                            interaction,
-                            "Error in leaderboard creation.",
-                            ephemeral=True,
-                        )
-                    return
+            success = await self.create_leaderboard_in_db(
+                interaction, leaderboard_name, date_value, task
+            )
+            if not success:
+                return
 
             forum_channel = self.bot.get_channel(self.bot.leaderboard_forum_id)
 
@@ -717,6 +731,56 @@ class LeaderboardCog(commands.Cog):
 
         with self.bot.leaderboard_db as db:  # Cleanup in case lb was created
             db.delete_leaderboard(leaderboard_name)
+
+    async def create_leaderboard_in_db(
+        self,
+        interaction: discord.Interaction,
+        leaderboard_name: str,
+        date_value: datetime,
+        task: LeaderboardTask,
+    ) -> bool:
+        # Ask the user to select GPUs
+        view = GPUSelectionView([gpu.name for gpu in GitHubGPU] + [gpu.name for gpu in ModalGPU])
+
+        await send_discord_message(
+            interaction,
+            "Please select GPUs for this leaderboard.",
+            view=view,
+            ephemeral=True,
+        )
+
+        await view.wait()
+
+        with self.bot.leaderboard_db as db:
+            err = db.create_leaderboard(
+                {
+                    "name": leaderboard_name,
+                    "deadline": date_value,
+                    "task": task,
+                    "gpu_types": view.selected_gpus,
+                    "creator_id": interaction.user.id,
+                }
+            )
+
+            if err:
+                if "duplicate key" in err:
+                    await send_discord_message(
+                        interaction,
+                        "Error: Tried to create a leaderboard "
+                        f'"{leaderboard_name}" that already exists.',
+                        ephemeral=True,
+                    )
+                else:
+                    # Handle any other errors
+                    logger.error(f"Error in leaderboard creation: {err}")
+                    await send_discord_message(
+                        interaction,
+                        "Error in leaderboard creation.",
+                        ephemeral=True,
+                    )
+                return False
+
+            return True
 
     @discord.app_commands.describe(leaderboard_name="Name of the leaderboard")
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -44,6 +44,11 @@ class ExitCode(IntEnum):
     VALIDATE_FAIL = 112
 
 
+class Language(Enum):
+    Python = "py"
+    CUDA = "cu"
+
+
 def combine_enums(enums: list[Type[Enum]], combined_name: str) -> Enum:
     combined_members = {}
     for enum in enums:

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -92,4 +92,4 @@ CUDA_FLAGS = [
     "-Xptxas=--verbose",
     "-Xptxas=--warn-on-spills",
 ]
-MODAL_CUDA_INCLUDE_DIRS = ["-I/ThunderKittens/include"]
+MODAL_CUDA_INCLUDE_DIRS = ["/ThunderKittens/include"]

--- a/src/discord-cluster-manager/report.py
+++ b/src/discord-cluster-manager/report.py
@@ -29,9 +29,12 @@ async def _send_split_log(thread: discord.Thread, partial_message: str, header: 
                 chunks.append(partial_message)
                 partial_message = line
 
+        if partial_message != "":
+            chunks.append(partial_message)
+
         # now, format the chunks
         for i, chunk in enumerate(chunks):
-            partial_message += f"\n\n## {header} ({i}/{len(chunks)}):\n"
+            partial_message += f"\n\n## {header} ({i+1}/{len(chunks)}):\n"
             partial_message += f"```\n{_limit_length(chunk, 1900)}```"
             await thread.send(partial_message)
 

--- a/src/discord-cluster-manager/task.py
+++ b/src/discord-cluster-manager/task.py
@@ -28,6 +28,8 @@ class LeaderboardTask:
     Attributes:
         lang: Programming language of this task. Specifies the type of
             the `data` attribute.
+        description: A description of the task.
+            TODO use for a sticky message for the LBs channel
         files: Dictionary containing a mapping of file names to file
             contents. Contents '@SUBMISSION@' get replaced with the
             submitted file before sending to the runner.
@@ -41,6 +43,7 @@ class LeaderboardTask:
     lang: Language
     files: dict[str, str]
     config: CudaTaskData | PythonTaskData
+    description: str = ''
     libraries: list[str] = dataclasses.field(default_factory=list)
 
     @staticmethod

--- a/src/discord-cluster-manager/task.py
+++ b/src/discord-cluster-manager/task.py
@@ -1,0 +1,123 @@
+import copy
+import dataclasses
+import json
+from pathlib import Path
+
+import leaderboard_eval
+from consts import Language
+
+
+@dataclasses.dataclass
+class CudaTaskData:
+    sources: list[str]
+    include_dirs: list[str] = dataclasses.field(default_factory=list)
+    defines: dict[str, str] = dataclasses.field(default_factory=dict)
+    compile_flags: list[str] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class PythonTaskData:
+    main: str
+
+
+@dataclasses.dataclass
+class LeaderboardTask:
+    """
+    Dataclass containing the definition of a task for the leaderboard
+
+    Attributes:
+        lang: Programming language of this task. Specifies the type of
+            the `data` attribute.
+        files: Dictionary containing a mapping of file names to file
+            contents. Contents '@SUBMISSION@' get replaced with the
+            submitted file before sending to the runner.
+        libraries: List of string identifiers for libraries available
+            (and potentially required) for this task. How these strings
+            are interpreted is up to the individual runner.
+        config: Language-specific task definition.
+
+    """
+
+    lang: Language
+    files: dict[str, str]
+    config: CudaTaskData | PythonTaskData
+    libraries: list[str] = dataclasses.field(default_factory=list)
+
+    @staticmethod
+    def from_dict(data: dict):
+        data_ = copy.copy(data)
+        lang = Language(data["lang"])
+        data_["lang"] = lang
+        if lang == Language.Python:
+            data_["config"] = PythonTaskData(**data["config"])
+        else:
+            data_["config"] = CudaTaskData(**data["config"])
+
+        return LeaderboardTask(**data_)
+
+    def to_dict(self) -> dict:
+        raw = dataclasses.asdict(self)
+        raw["lang"] = raw["lang"].value
+        return raw
+
+    def to_str(self):
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @staticmethod
+    def from_str(data: str):
+        return LeaderboardTask.from_dict(json.loads(data))
+
+
+def make_task(yaml_file: str) -> LeaderboardTask:
+    import yaml
+
+    with open(yaml_file) as f:
+        raw = yaml.safe_load(f)
+
+    user_file_name = raw.get("user_file_name", None)
+
+    # now, build file dict
+    file_dict = {}
+    for file_spec in raw["files"]:
+        name = file_spec["name"]
+        source = file_spec["source"]
+
+        # handle special files
+        if source == "@SUBMISSION@":
+            assert user_file_name is None
+            file_dict[name] = "@SUBMISSION@"
+        elif source == "@EVAL_CU@":
+            file_dict[name] = leaderboard_eval.cu_eval
+        elif source == "@EVAL_PY@":
+            file_dict[name] = leaderboard_eval.py_eval
+        else:
+            file_dict[name] = Path(source).read_text()
+
+    raw["files"] = file_dict
+    return LeaderboardTask.from_dict(raw)
+
+
+# TODO remove this as soon as possible
+def build_from_legacy_reference(ref: str):
+    if "#include " in ref:
+        lang = Language.CUDA
+        config = CudaTaskData(sources=["eval.cu"])
+        files = {
+            "eval.cu": leaderboard_eval.cu_eval,
+            "reference.cuh": ref,
+            "submission.cuh": "@SUBMISSION@",
+        }
+    elif "import " in ref:
+        lang = Language.Python
+        config = PythonTaskData(main="eval.py")
+        files = {
+            "eval.py": leaderboard_eval.py_eval,
+            "reference.py": ref,
+            "submission.py": "@SUBMISSION@",
+        }
+
+    return LeaderboardTask(lang=lang, files=files, config=config, libraries=[])
+
+
+if __name__ == "__main__":
+    print(json.dumps(make_task("task.yml").to_dict(), indent=4))

--- a/src/discord-cluster-manager/task.py
+++ b/src/discord-cluster-manager/task.py
@@ -86,10 +86,6 @@ def make_task(yaml_file: str) -> LeaderboardTask:
         if source == "@SUBMISSION@":
             assert user_file_name is None
             file_dict[name] = "@SUBMISSION@"
-        elif source == "@EVAL_CU@":
-            file_dict[name] = leaderboard_eval.cu_eval
-        elif source == "@EVAL_PY@":
-            file_dict[name] = leaderboard_eval.py_eval
         else:
             file_dict[name] = Path(source).read_text()
 

--- a/src/discord-cluster-manager/task.py
+++ b/src/discord-cluster-manager/task.py
@@ -68,7 +68,7 @@ class LeaderboardTask:
         return LeaderboardTask.from_dict(json.loads(data))
 
 
-def make_task(yaml_file: str) -> LeaderboardTask:
+def make_task(yaml_file: str | Path) -> LeaderboardTask:
     import yaml
 
     with open(yaml_file) as f:

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -5,8 +5,8 @@ import subprocess
 from typing import Any, List, NotRequired, TypedDict
 
 import discord
-from consts import MODAL_CUDA_INCLUDE_DIRS
-from leaderboard_eval import cu_eval, py_eval
+from consts import MODAL_CUDA_INCLUDE_DIRS, Language
+from task import LeaderboardTask
 
 
 def setup_logging():
@@ -169,7 +169,7 @@ class LeaderboardItem(TypedDict):
     name: str
     creator_id: int
     deadline: datetime.datetime
-    reference_code: str
+    task: LeaderboardTask
     gpu_types: List[str]
 
 
@@ -187,21 +187,24 @@ class SubmissionItem(TypedDict):
 
 
 def build_task_config(
-    lang: str, reference_content: str = None, submission_content: str = None, arch: str = None
+    task: LeaderboardTask = None, submission_content: str = None, arch: str = None
 ) -> dict:
-    eval_name = {"py": "eval.py", "cu": "eval.cu"}[lang]
+    if task is None:
+        # TODO detect language
+        lang = "py"
 
-    config = {
-        "lang": lang,
-        "arch": arch,
-    }
+        config = {
+            "lang": lang,
+            "arch": arch,
+        }
 
-    if lang == "py":
-        config["main"] = "eval.py"
-    else:
-        config["include_dirs"] = MODAL_CUDA_INCLUDE_DIRS
+        eval_name = {"py": "eval.py", "cu": "eval.cu"}[lang]
 
-    if reference_content is None:
+        if lang == "py":
+            config["main"] = "eval.py"
+        else:
+            config["include_dirs"] = MODAL_CUDA_INCLUDE_DIRS
+
         return {
             **config,
             "sources": {
@@ -209,23 +212,33 @@ def build_task_config(
             },
         }
     else:
-        if lang == "py":
+        all_files = {}
+        for n, c in task.files.items():
+            if c == "@SUBMISSION@":
+                all_files[n] = submission_content
+            else:
+                all_files[n] = c
+
+        if task.lang == Language.Python:
             return {
-                **config,
-                "sources": {
-                    "eval.py": py_eval,
-                    "reference.py": reference_content,
-                    "submission.py": submission_content,
-                },
+                "lang": task.lang.value,
+                "arch": arch,
+                "main": task.config.main,
+                "sources": all_files,
             }
         else:
+            sources = {}
+            headers = {}
+            for f in all_files:
+                if f in task.config.sources:
+                    sources[f] = all_files[f]
+                else:
+                    headers[f] = all_files[f]
+
             return {
-                **config,
-                "sources": {
-                    "eval.cu": cu_eval,
-                },
-                "headers": {
-                    "reference.cuh": reference_content,
-                    "submission.cuh": submission_content,
-                },
+                "lang": task.lang.value,
+                "arch": arch,
+                "sources": sources,
+                "headers": headers,
+                "include_dirs": task.config.include_dirs,
             }


### PR DESCRIPTION
Store generic task definitions as json string in the database (abusing the existing reference_code field for now).
This allows us to easily define multi-file tasks, have different eval scripts for different tasks (even though its possible, in general we should avoid that, I think)
Currently, I've copied (and then adapted) the file, but once we have the tasks repo, we can just symlink the eval.cu master copy into the individual tasks so we won't have to maintain multiple copies (with the option to make breaking changes for newer tasks without having to worry about existing ones, yay)

The identity exampe shows roughly how I envision task definitions to look like.  In particular, we have a task.h that just defines the interface, and then we won't have to include the submission in the main file, and instead can compile it separately. We could also separate out the reference code, not sure if we want to, though.

To facilitate development and testing, I've added a command that creates a leaderboard from a local directory. It can overwrite an existing leaderboard, so you can iterate quickly.

I've added some translation code that attempts to take leaderboards that are still in their current format and map them to the new one. That code is pretty much untested.