### PR TITLE
Add mi300x to the amd workflow matrix.

### DIFF
--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -1,5 +1,7 @@
 name: AMD PyTorch Job
 on:
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       payload:
@@ -63,6 +65,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: run-result
+        name: run-result-${{ matrix.name }}
         path: |
           result.json

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -13,10 +13,18 @@ on:
 
 jobs:
   run:
-    runs-on: [amdgpu-mi250-x86-64]
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: mi300
+            runs-on: amdgpu-mi300-x86-64
+            venv-dir: ${{ github.workspace }}
+          - name: mi250
+            runs-on: amdgpu-mi300-x86-64
+            venv-dir: /groups/aig_sharks/pytorch_venv
     timeout-minutes: 10
-    env:
-      VENV_DIR: /groups/aig_sharks/pytorch_venv
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python
@@ -35,8 +43,8 @@ jobs:
     - name: Setup Virtual Environment and Install Dependencies
       shell: bash
       run: |
-        python -m venv ${VENV_DIR}
-        source ${VENV_DIR}/bin/activate
+        python -m venv ${{ matrix.venv-dir }}
+        source ${{ matrix.venv-dir }}/bin/activate
         pip install --upgrade pip
 
         if [[ -n "${{ github.event.inputs.requirements }}" ]]; then


### PR DESCRIPTION
## Description

This commit adds mi300 nodes to the current amd workflow matrix.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
