### PR TITLE
Add MI300X Runners to AMD workflow.

### DIFF
--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -68,6 +68,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: run-result-${{ matrix.name }}
+        name: run-result
         path: |
           result.json

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -13,10 +13,18 @@ on:
 
 jobs:
   run:
-    runs-on: [amdgpu-mi250-x86-64]
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: mi300
+            runs-on: amdgpu-mi300-x86-64
+            venv-dir: ${{ github.workspace }}
+          - name: mi250
+            runs-on: amdgpu-mi300-x86-64
+            venv-dir: /groups/aig_sharks/pytorch_venv
     timeout-minutes: 10
-    env:
-      VENV_DIR: /groups/aig_sharks/pytorch_venv
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python
@@ -35,8 +43,8 @@ jobs:
     - name: Setup Virtual Environment and Install Dependencies
       shell: bash
       run: |
-        python -m venv ${VENV_DIR}
-        source ${VENV_DIR}/bin/activate
+        python -m venv ${{ matrix.venv-dir }}
+        source ${{ matrix.venv-dir }}/bin/activate
         pip install --upgrade pip
 
         if [[ -n "${{ github.event.inputs.requirements }}" ]]; then
@@ -55,6 +63,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: run-result
+        name: run-result-${{ matrix.name }}
         path: |
           result.json

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Run script
       shell: bash
       run: |
+        source ${{ matrix.venv-dir }}/bin/activate
         python3 .github/workflows/runner.py
         cat result.json  # Debug: show output
 

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -46,7 +46,7 @@ jobs:
         python -m venv ${{ matrix.venv-dir }}
         source ${{ matrix.venv-dir }}/bin/activate
         pip install --upgrade pip
-
+        pip install torch pytorch-triton-rocm --index-url https://download.pytorch.org/whl/nightly/rocm6.2
         if [[ -n "${{ github.event.inputs.requirements }}" ]]; then
           cat > "requirements.txt" <<'EOL'
           ${{ github.event.inputs.requirements }}

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -20,9 +20,9 @@ jobs:
         include:
           - name: mi300
             runs-on: amdgpu-mi300-x86-64
-            venv-dir: ${{ github.workspace }}
+            venv-dir: $GITHUB_WORKSPACE
           - name: mi250
-            runs-on: amdgpu-mi300-x86-64
+            runs-on: amdgpu-mi250-x86-64
             venv-dir: /groups/aig_sharks/pytorch_venv
     timeout-minutes: 10
     steps:

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       runner:
-        description: 'Contents for a requirements.txt file'
+        description: 'AMD runner to run workflow on'
         required: true
         default: "amdgpu-mi300-x86-64"
         type: string

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -6,6 +6,11 @@ on:
         description: 'Content of the user submission, as json string'
         required: true
         type: string
+      runner:
+        description: 'Contents for a requirements.txt file'
+        required: true
+        default: "amdgpu-mi300-x86-64"
+        type: string
       requirements:
         description: 'Contents for a requirements.txt file'
         required: false
@@ -13,17 +18,9 @@ on:
 
 jobs:
   run:
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ github.event.inputs.runner }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: mi300
-            runs-on: amdgpu-mi300-x86-64
-            venv-dir: $GITHUB_WORKSPACE
-          - name: mi250
-            runs-on: amdgpu-mi250-x86-64
-            venv-dir: /groups/aig_sharks/pytorch_venv
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
@@ -32,19 +29,26 @@ jobs:
       with:
         python-version: '3.10'
 
-
     - name: Create input files
       shell: bash
       run: |
         cat > "payload.json" <<'EOL'
         ${{ github.event.inputs.payload }}
         EOL
+    
+    - name: Set venv directory based on runner
+      run: |
+        if [[ "${{ github.event.inputs.runner }}" == "amdgpu-mi250-x86-64" ]]; then
+          echo "VENV_DIR=/groups/aig_sharks/pytorch_venv" >> $GITHUB_ENV
+        else
+          echo "VENV_DIR==$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        fi
 
     - name: Setup Virtual Environment and Install Dependencies
       shell: bash
       run: |
-        python -m venv ${{ matrix.venv-dir }}
-        source ${{ matrix.venv-dir }}/bin/activate
+        python -m venv ${VENV_DIR}
+        source ${VENV_DIR}/bin/activate
         pip install --upgrade pip
         if [[ -n "${{ github.event.inputs.requirements }}" ]]; then
           cat > "requirements.txt" <<'EOL'
@@ -52,10 +56,11 @@ jobs:
         EOL
         pip install -r "requirements.txt"
         fi
+
     - name: Run script
       shell: bash
       run: |
-        source ${{ matrix.venv-dir }}/bin/activate
+        source ${VENV_DIR}/bin/activate
         python3 .github/workflows/runner.py
         cat result.json  # Debug: show output
 

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -46,7 +46,6 @@ jobs:
         python -m venv ${{ matrix.venv-dir }}
         source ${{ matrix.venv-dir }}/bin/activate
         pip install --upgrade pip
-        pip install torch pytorch-triton-rocm --index-url https://download.pytorch.org/whl/nightly/rocm6.2
         if [[ -n "${{ github.event.inputs.requirements }}" ]]; then
           cat > "requirements.txt" <<'EOL'
           ${{ github.event.inputs.requirements }}

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -29,7 +29,13 @@ class GitHubCog(SubmitCog):
 
         lang_name = {"py": "Python", "cu": "CUDA"}[lang]
 
+        if selected_gpu = GPUType.AMD:
+            gpu_name = config.get("gpu", "mi300")
+            runner_name = {"mi250": "amdgpu-mi250-x86-64", "mi300": "amdgpu-mi300-x86-64"}[gpu_name]
+
         logger.info(f"Attempting to trigger GitHub action for {lang_name} on {selected_gpu.name}")
+        if selected_gpu = GPUType.AMD:
+            logger.info(f"Running on {gpu_name} amd gpu")
 
         workflow_file = selected_gpu.value
         run = GitHubRun(workflow_file)
@@ -42,7 +48,7 @@ class GitHubCog(SubmitCog):
                 inputs["requirements"] = NVIDIA_REQUIREMENTS
             else:
                 inputs["requirements"] = AMD_REQUIREMENTS
-
+                inputs["runner"] = runner_name
         if not await run.trigger(inputs):
             raise RuntimeError("Failed to trigger GitHub Action. Please check the configuration.")
 

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -29,12 +29,12 @@ class GitHubCog(SubmitCog):
 
         lang_name = {"py": "Python", "cu": "CUDA"}[lang]
 
-        if selected_gpu = GPUType.AMD:
+        if selected_gpu == GPUType.AMD:
             gpu_name = config.get("gpu", "mi300")
             runner_name = {"mi250": "amdgpu-mi250-x86-64", "mi300": "amdgpu-mi300-x86-64"}[gpu_name]
 
         logger.info(f"Attempting to trigger GitHub action for {lang_name} on {selected_gpu.name}")
-        if selected_gpu = GPUType.AMD:
+        if selected_gpu == GPUType.AMD:
             logger.info(f"Running on {gpu_name} amd gpu")
 
         workflow_file = selected_gpu.value


### PR DESCRIPTION
## Description

This commit adds mi300 nodes as an option to the current amd workflow.

I tested a couple times on the AMD workflow here (https://github.com/gpu-mode/discord-cluster-manager/actions/runs/12902691574)

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
