### PR TITLE
Fix: application timeout in fast-track if only 1 gpu

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -102,9 +102,6 @@ class LeaderboardSubmitCog(app_commands.Group):
         """
         UI displayed to user to select GPUs that they want to use.
         """
-        if not interaction.response.is_done():
-            await interaction.response.defer(ephemeral=True)
-
         view = GPUSelectionView(gpus)
 
         await send_discord_message(
@@ -200,6 +197,8 @@ class LeaderboardSubmitCog(app_commands.Group):
 
         # if there is more than one candidate GPU, display UI to let user select,
         # otherwise just run on that GPU
+        if not interaction.response.is_done():
+            await interaction.response.defer(ephemeral=True)
         if len(gpus) == 1:
             selected_gpus = gpus
         else:

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -200,6 +200,11 @@ class LeaderboardSubmitCog(app_commands.Group):
         if not interaction.response.is_done():
             await interaction.response.defer(ephemeral=True)
         if len(gpus) == 1:
+            await send_discord_message(
+                interaction,
+                f"Running on GPU: **{gpus[0]}**",
+                ephemeral=True,
+            )
             selected_gpus = gpus
         else:
             view = await self.select_gpu_view(interaction, leaderboard_name, gpus)


### PR DESCRIPTION
Description

Small fix, PR #144 introduced a subtle bug that if only 1 gpu was available, it would not call gpu_view, resulting in the interaction defer not being called. As only 1 command calls this view, I moved the defer into the command as it's not view specific.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
