### PR TITLE
Make run_cuda_script accept more compile flags arguments

### DIFF
--- a/scripts/ci_test_python.py
+++ b/scripts/ci_test_python.py
@@ -39,7 +39,6 @@ def custom_kernel(input):
     run = run_pytorch_script(
         {"eval.py": py_eval, "reference.py": ref.read_text(), "submission.py": sub},
         "eval.py",
-        arch=None,
     )
     assert run.success is True
     assert run.passed is False

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -2,7 +2,7 @@ import asyncio
 
 import modal
 from cogs.submit_cog import ProgressReporter, SubmitCog
-from consts import GPU_TO_SM, GPUType, ModalGPU
+from consts import GPU_TO_SM, MODAL_CUDA_INCLUDE_DIRS, GPUType, ModalGPU
 from discord import app_commands
 from run_eval import FullResult
 from utils import setup_logging
@@ -21,6 +21,8 @@ class ModalCog(SubmitCog):
         self, config: dict, gpu_type: GPUType, status: ProgressReporter
     ) -> FullResult:
         loop = asyncio.get_event_loop()
+        if config["lang"] == "cu":
+            config["include_dirs"] = config.get("include_dirs", []) + MODAL_CUDA_INCLUDE_DIRS
         func_type = "pytorch" if config["lang"] == "py" else "cuda"
         func_name = f"run_{func_type}_script_{gpu_type.value.lower()}"
 

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -87,4 +87,4 @@ CUDA_FLAGS = [
     "-Xptxas=--verbose",
     "-Xptxas=--warn-on-spills",
 ]
-MODAL_CUDA_INCLUDE_DIRS = ["-I/ThunderKittens/include"]
+MODAL_CUDA_INCLUDE_DIRS = ["/ThunderKittens/include"]

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -60,6 +60,19 @@ def _limit_length(text: str, max_len: int = 16384):
     return text
 
 
+def _create_files(files: dict[str, str]):
+    """
+    Create text files
+    Args:
+        files: A dictionary mapping file names to their contents.
+    Raises:
+        AssertionError, if the file is not within the current working directory.
+    """
+    for name, content in files.items():
+        assert Path(name).resolve().is_relative_to(Path.cwd())
+        Path(name).write_text(content)
+
+
 def compile_cuda_script(  # # noqa: C901
     files: list[str],
     arch: int = None,
@@ -207,11 +220,8 @@ def run_cuda_script(  # # noqa: C901
 
     try:
         # Write submission files to directory
-        for source, content in sources.items():
-            Path(source).write_text(content)
-
-        for header, content in headers.items():
-            Path(header).write_text(content)
+        _create_files(sources)
+        _create_files(headers)
 
         compile_result = compile_cuda_script(
             files=list(sources.keys()),
@@ -266,8 +276,7 @@ def run_pytorch_script(  # noqa: C901
         assert main in sources.keys()
 
         # Write submission files to directory
-        for source, content in sources.items():
-            Path(source).write_text(content)
+        _create_files(sources)
         return run_program(["python", main], seed=seed)
 
     finally:

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -5,7 +5,6 @@ import subprocess
 from typing import Any, List, NotRequired, TypedDict
 
 import discord
-from consts import MODAL_CUDA_INCLUDE_DIRS
 from leaderboard_eval import cu_eval, py_eval
 
 
@@ -198,8 +197,6 @@ def build_task_config(
 
     if lang == "py":
         config["main"] = "eval.py"
-    else:
-        config["include_dirs"] = MODAL_CUDA_INCLUDE_DIRS
 
     if reference_content is None:
         return {


### PR DESCRIPTION
## Description
* Adds additional arguments for cuda compiles that allow specifying link libraries, defines, and generic flags.
* Additional verification and unit tests.

The additional checks that supplied include directories actually exist required to move the modal-specific thunderkittens include into the modal cog.