### PR TITLE
Fix: add requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,7 @@ psycopg2-binary
 yoyo-migrations
 ruff
 pre-commit
+
+# api
+fastapi
+uvicorn


### PR DESCRIPTION
## Description

Small pr to fix deploy to heroku (forgot to add reqs in #143)

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
