### PR TITLE
Update of result structures and eval runs

### DIFF
--- a/.github/workflows/runner.py
+++ b/.github/workflows/runner.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from dataclasses import asdict
+from datetime import datetime
 from pathlib import Path
 
 sys.path.append("src/discord-cluster-manager")
@@ -12,4 +13,12 @@ Path("payload.json").unlink()
 
 result = asdict(run_config(config))
 
-Path("result.json").write_text(json.dumps(result))
+
+# ensure valid serialization
+def serialize(obj: object):
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+
+Path("result.json").write_text(json.dumps(result, default=serialize))

--- a/scripts/ci_test_cuda.py
+++ b/scripts/ci_test_cuda.py
@@ -25,7 +25,7 @@ def run_cuda_helper(sources: dict, headers: dict = None, arch=None, **kwargs):
     if headers is None:
         headers = header_files
 
-    comp, runs = run_cuda_script(
+    eval_result = run_cuda_script(
         sources,
         headers,
         arch=arch,
@@ -33,8 +33,7 @@ def run_cuda_helper(sources: dict, headers: dict = None, arch=None, **kwargs):
         tests="size: 256; seed: 42\n",
         **kwargs,
     )
-    run = runs.get("test", None)
-    return comp, run
+    return eval_result.compilation, eval_result.run
 
 
 def test_does_not_compile():
@@ -201,13 +200,14 @@ def test_include_dirs(tmp_path: Path):
     assert run.result["check"] == "pass"
 
     # can also use generic flags argument
-    comp, run = run_cuda_script(
+    result = run_cuda_script(
         {"eval.cu": eval_cu, "submission.cu": sub},
         header_files,
         flags=["-I.", f"-I{tmp_path}"],
+        mode="script",
     )
 
-    assert comp.success is True
+    assert result.compilation.success is True
 
 
 def test_link_libs(tmp_path: Path):

--- a/scripts/ci_test_python.py
+++ b/scripts/ci_test_python.py
@@ -18,11 +18,10 @@ files = {"eval.py": py_eval, "reference.py": ref, "utils.py": utils, "task.py": 
 
 
 def run_pytorch_helper(sources: dict, **kwargs):
-    runs = run_pytorch_script(
+    result = run_pytorch_script(
         sources, "eval.py", mode=SubmissionMode.TEST.value, tests="size: 256; seed: 42\n", **kwargs
     )
-    run = runs.get("test", None)
-    return run
+    return result.run
 
 
 def test_does_not_import():

--- a/scripts/ci_test_python.py
+++ b/scripts/ci_test_python.py
@@ -90,3 +90,20 @@ def custom_kernel(input):
     assert run.success
     assert len(run.stderr) < 16384
     assert "[...]" in run.stderr
+
+
+def test_timeout():
+    sub = """
+from task import input_t, output_t
+import time
+
+def custom_kernel(data: input_t) -> output_t:
+    time.sleep(5)
+    return data
+"""
+
+    run = run_pytorch_helper({**files, "submission.py": sub}, test_timeout=2)
+    assert run.success is False
+    assert run.stdout == ""
+    assert run.exit_code == ExitCode.TIMEOUT_EXPIRED
+    assert len(run.result) == 0

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -5,7 +5,7 @@ from cogs.submit_cog import ProgressReporter, SubmitCog
 from consts import AMD_REQUIREMENTS, NVIDIA_REQUIREMENTS, GitHubGPU, GPUType
 from discord import app_commands
 from github_runner import GitHubRun
-from run_eval import CompileResult, FullResult, RunResult, EvalResult
+from run_eval import CompileResult, EvalResult, FullResult, RunResult
 from utils import setup_logging
 
 logger = setup_logging()
@@ -62,9 +62,7 @@ class GitHubCog(SubmitCog):
         if "run-result" not in artifacts:
             logger.error("Could not find `run-result` among artifacts: %s", artifacts.keys())
             await status.push("Downloading artifacts...  failed")
-            return FullResult(
-                success=False, error="Could not download artifacts", runs={}
-            )
+            return FullResult(success=False, error="Could not download artifacts", runs={})
 
         logs = artifacts["run-result"]["result.json"].decode("utf-8")
 
@@ -80,10 +78,12 @@ class GitHubCog(SubmitCog):
             else:
                 comp = None
             run = RunResult(**v["run"])
-            res = EvalResult(start=datetime.datetime.fromisoformat(v['start']),
-                             end=datetime.datetime.fromisoformat(v['end']),
-                             compilation=comp,
-                             run=run)
+            res = EvalResult(
+                start=datetime.datetime.fromisoformat(v["start"]),
+                end=datetime.datetime.fromisoformat(v["end"]),
+                compilation=comp,
+                run=run,
+            )
             runs[k] = res
 
         return FullResult(success=True, error="", runs=runs)

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -73,7 +73,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                     else interaction.user.nick
                 )
 
-                if result.runs["test"].result["check"] != "pass":
+                if result.runs["test"].run.result["check"] != "pass":
                     await discord_thread.send(
                         f"Ran on {gpu.name} using {runner_name} runners!\n"
                         + f"Leaderboard '{leaderboard_name}'.\n"
@@ -84,9 +84,9 @@ class LeaderboardSubmitCog(app_commands.Group):
 
                 # TODO: Make this more flexible, not just functional
                 score = 0.0
-                num_benchmarks = int(result.runs["benchmark"].result["benchmark-count"])
+                num_benchmarks = int(result.runs["benchmark"].run.result["benchmark-count"])
                 for i in range(num_benchmarks):
-                    score += float(result.runs["benchmark"].result[f"benchmark.{i}.mean"]) / 1e9
+                    score += float(result.runs["benchmark"].run.result[f"benchmark.{i}.mean"]) / 1e9
                 score /= num_benchmarks
 
                 # TODO: specify what LB it saves to

--- a/src/discord-cluster-manager/modal_runner.py
+++ b/src/discord-cluster-manager/modal_runner.py
@@ -84,9 +84,15 @@ def modal_run_config(  # noqa: C901
         with timeout(timeout_seconds):
             return run_config(config)
     except TimeoutException as e:
-        return FullResult(success=False, error=f"Timeout Error: {str(e)}", compile=None, runs={})
+        return FullResult(
+            success=False,
+            error=f"Timeout Error: {str(e)}",
+            runs={},
+        )
     except Exception as e:
         exception = "".join(traceback.format_exception(e))
         return FullResult(
-            success=False, error=f"Error executing script:\n{exception}", compile=None, runs={}
+            success=False,
+            error=f"Error executing script:\n{exception}",
+            runs={},
         )

--- a/src/discord-cluster-manager/report.py
+++ b/src/discord-cluster-manager/report.py
@@ -294,10 +294,14 @@ async def generate_report(thread: discord.Thread, result: FullResult, mode: Subm
     if len(runs) == 1:
         run = next(iter(runs.values()))
         if len(run.run.stderr.strip()) > 0:
-            message = await _send_split_log(thread, message, "Program stderr", run.run.stderr.strip())
+            message = await _send_split_log(
+                thread, message, "Program stderr", run.run.stderr.strip()
+            )
 
         if len(run.run.stdout.strip()) > 0:
-            message = await _send_split_log(thread, message, "Program stdout", run.run.stdout.strip())
+            message = await _send_split_log(
+                thread, message, "Program stdout", run.run.stdout.strip()
+            )
 
     if len(message) != 0:
         await thread.send(message)

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 from pathlib import Path
 from types import NoneType
-from typing import Optional, Union, Protocol
+from typing import Optional, Protocol, Union
 
 from consts import CUDA_FLAGS, ExitCode
 
@@ -43,7 +43,7 @@ class RunResult:
 @dataclasses.dataclass
 class EvalResult:
     # fmt: off
-    start: datetime.datetime            # when did this run start (excluding any container setup time)
+    start: datetime.datetime            # when did this run start (excluding container setup time)
     end: datetime.datetime              # and when did it finish
     compilation: CompileResult | None   # results of compilation
     run: RunResult | None               # result of actually running the executable/script
@@ -304,7 +304,7 @@ def run_cuda_script(  # # noqa: C901
     include_dirs: Optional[list[str]] = None,
     libraries: Optional[list[str]] = None,
     flags: Optional[list[str]] = None,
-    **kwargs
+    **kwargs,
 ) -> EvalResult:
     """
     Executes the provided CUDA kernel in an isolated environment
@@ -444,12 +444,12 @@ def build_test_string(tests: list[dict]):
 
 def run_config(config: dict):
     common_args = {
-        "tests":  build_test_string(config.get("tests", [])),
+        "tests": build_test_string(config.get("tests", [])),
         "benchmarks": build_test_string(config.get("benchmarks", [])),
         "test_timeout": config.get("test_timeout", 30),
         "benchmark_timeout": config.get("benchmark_timeout", 60),
         "ranked_timeout": config.get("ranked_timeout", 30),
-        "seed": 42
+        "seed": 42,
     }
     if config["lang"] == "py":
         runner = functools.partial(

--- a/src/discord-cluster-manager/task.py
+++ b/src/discord-cluster-manager/task.py
@@ -44,6 +44,8 @@ class LeaderboardTask:
             as a dict mapping function argument names to their values.
         benchmarks: List of benchmark specifications (same format as tests)
         templates: Template files for participants to download
+        test_timeout, benchmark_timeout, ranked_timeout: Timeouts for running
+            tests, benchmarks, and ranked submissions.
 
     """
 
@@ -53,7 +55,10 @@ class LeaderboardTask:
     description: str = ""
     libraries: list[str] = dataclasses.field(default_factory=list)
     tests: list[TestCaseType] = dataclasses.field(default_factory=list)
+    test_timeout: int = 30
     benchmarks: list[TestCaseType] = dataclasses.field(default_factory=list)
+    benchmark_timeout: int = 60
+    ranked_timeout: int = 90
     templates: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @staticmethod


### PR DESCRIPTION
Update evalulation runs:
* Attach a potential compile result to _each_ run (we might want to compile tests without `-DNDEBUG`, for example; not part of this PR, though)
* record start and end time of runs
* have task specific timeouts for test, benchmark, and ranked runs, with reasonable defaults (i hope; maybe they should be even lower?)
* restructuring of eval code

Testing these changes requires making a deploy to modal so the new test script is there.