### PR TITLE
msaroufim/test amd

### DIFF
--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -139,7 +139,5 @@ triton
 """
 
 AMD_REQUIREMENTS = """
---index-url https://download.pytorch.org/whl/nightly/rocm6.2
-pytorch-triton-rocm==3.1.0+cf34004b8a
-torch==2.6.0.dev20241023+rocm6.2
+--index-url https://download.pytorch.org/whl/rocm6.2.4
 """

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -140,4 +140,5 @@ triton
 
 AMD_REQUIREMENTS = """
 --index-url https://download.pytorch.org/whl/rocm6.2.4
+torch
 """


### PR DESCRIPTION
AMD requirements are now failing with

```
 ERROR: Could not find a version that satisfies the requirement torch==2.6.0.dev20241023+rocm6.2 (from versions: 2.6.0.dev20241122+rocm6.2)
ERROR: No matching distribution found for torch==2.6.0.dev20241023+rocm6.2
```

We are using an "old" nightly version which was likely recently purged from the PyTorch index, instead we'll use the stable release for 6.2.4 and remove the explicit installation of triton since PyTorch also packages triton when making releases

This fixes that issue but now there's another real looking failure in the leaderboard code https://github.com/gpu-mode/discord-cluster-manager/actions/runs/13422933345/job/37499644756