### PR TITLE
Database update to record submissions

### DIFF
--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -76,6 +76,10 @@ class AdminCog(commands.Cog):
             name="update-problems", description="Reload all problem definitions"
         )(self.update_problems)
 
+        self.show_bot_stats = bot.admin_group.command(
+            name="show-stats", description="Show stats for the bot"
+        )(self.show_bot_stats)
+
     # --------------------------------------------------------------------------
     # |                           HELPER FUNCTIONS                              |
     # --------------------------------------------------------------------------
@@ -585,3 +589,12 @@ class AdminCog(commands.Cog):
             await interaction.edit_original_response(content=f"{header}\n\n{plan}\n\n{steps}")
         except Exception as e:
             logger.exception("Error updating problem set", exc_info=e)
+
+    async def show_bot_stats(self, interaction: discord.Interaction):
+        with self.bot.leaderboard_db as db:
+            stats = db.generate_stats()
+            msg = """```"""
+            for k, v in stats.items():
+                msg += f"\n{k} = {v}"
+            msg += "\n```"
+            await send_discord_message(interaction, msg, ephemeral=True)

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -67,7 +67,10 @@ class LeaderboardSubmitCog(app_commands.Group):
                     else interaction.user.nick
                 )
 
-                if result.runs["test"].run.result["check"] != "pass":
+                if (
+                    "test" in result.runs
+                    and result.runs["test"].run.result.get("check", "") != "pass"
+                ):
                     await discord_thread.send(
                         f"Ran on {gpu.name} using {runner_name} runners!\n"
                         + f"Leaderboard '{leaderboard_name}'.\n"

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -1,3 +1,6 @@
+import dataclasses
+import datetime
+import json
 import logging
 from typing import List, Optional
 
@@ -12,8 +15,9 @@ from env import (
     POSTGRES_USER,
 )
 from psycopg2 import Error
+from run_eval import CompileResult, RunResult
 from task import LeaderboardTask
-from utils import LeaderboardItem, LRUCache, SubmissionItem
+from utils import LeaderboardItem, LeaderboardRankedEntry, LRUCache
 
 leaderboard_name_cache = LRUCache(max_size=512)
 
@@ -144,31 +148,125 @@ class LeaderboardDB:
             self.connection.commit()
             leaderboard_name_cache.invalidate()  # Invalidate autocomplete cache
         except psycopg2.Error as e:
+            logging.exception("error in delete_leaderboard", exc_info=e)
             self.connection.rollback()
             return f"Error during leaderboard deletion: {e}"
         return None
 
-    def create_submission(self, submission: SubmissionItem):
+    def create_submission(
+        self, leaderboard: str, file_name: str, user_id: int, code: str, time: datetime.datetime
+    ) -> Optional[int]:
+        try:
+            # check if we already have the code
+            self.cursor.execute(
+                """
+                SELECT id, code
+                FROM leaderboard.code_files
+                WHERE hash = encode(sha256(%s::bytea), 'hex')
+                """,
+                (code,),
+            )
+
+            code_id = None
+            for candidate in self.cursor.fetchall():
+                if candidate[1] == code:
+                    code_id = candidate[0]
+                    break
+
+            if code_id is None:
+                # a genuinely new submission
+                self.cursor.execute(
+                    """
+                    INSERT INTO leaderboard.code_files (CODE)
+                    VALUES (%s)
+                    RETURNING id
+                    """,
+                    (code,),
+                )
+                code_id = self.cursor.fetchone()
+
+            self.cursor.execute(
+                """
+                INSERT INTO leaderboard.submission (leaderboard_id, file_name,
+                    user_id, code_id, submission_time)
+                VALUES (
+                    (SELECT id FROM leaderboard.leaderboard WHERE name = %s),
+                    %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    leaderboard,
+                    file_name,
+                    user_id,
+                    code_id,
+                    time,
+                ),
+            )
+            submission_id = self.cursor.fetchone()[0]
+            assert submission_id is not None
+            self.connection.commit()
+            return submission_id
+        except psycopg2.Error as e:
+            print(f"Error during leaderboard submission: {e}")
+            self.connection.rollback()  # Ensure rollback if error occurs
+
+    def mark_submission_done(
+        self,
+        submission: int,
+    ) -> Optional[int]:
         try:
             self.cursor.execute(
                 """
-                INSERT INTO leaderboard.submission (leaderboard_id, name,
-                    user_id, code, submission_time, score, gpu_type, stdout,
-                    profiler_output)
-                VALUES (
-                    (SELECT id FROM leaderboard.leaderboard WHERE name = %s),
-                    %s, %s, %s, %s, %s, %s, %s, %s)
+                UPDATE leaderboard.submission
+                SET done = TRUE
+                WHERE id = %s
+                """,
+                (submission,),
+            )
+            self.connection.commit()
+        except psycopg2.Error as e:
+            print(f"Error during leaderboard submission: {e}")
+            self.connection.rollback()  # Ensure rollback if error occurs
+
+    def create_submission_run(
+        self,
+        submission: int,
+        start: datetime.datetime,
+        end: datetime.datetime,
+        mode: str,
+        secret: bool,
+        runner: str,
+        score: Optional[float],
+        compilation: Optional[CompileResult],
+        result: RunResult,
+    ):
+        try:
+            if compilation is not None:
+                compilation = json.dumps(dataclasses.asdict(compilation))
+
+            meta = {
+                k: result.__dict__[k]
+                for k in ["stdout", "stderr", "success", "exit_code", "command", "duration"]
+            }
+            self.cursor.execute(
+                """
+                INSERT INTO leaderboard.runs (submission_id, start_time, end_time, mode,
+                secret, runner, score, passed, compilation, meta, result
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
-                    submission["leaderboard_name"],
-                    submission["submission_name"],
-                    submission["user_id"],
-                    submission["code"],
-                    submission["submission_time"],
-                    submission["submission_score"],
-                    submission["gpu_type"],
-                    submission.get("stdout", None),
-                    submission.get("profiler_output", None),
+                    submission,
+                    start,
+                    end,
+                    mode,
+                    secret,
+                    runner,
+                    score,
+                    result.passed,
+                    compilation,
+                    json.dumps(meta),
+                    json.dumps(result.result),
                 ),
             )
             self.connection.commit()
@@ -257,20 +355,21 @@ class LeaderboardDB:
 
     def get_leaderboard_submissions(
         self, leaderboard_name: str, gpu_name: str, user_id: Optional[str] = None
-    ) -> list[SubmissionItem]:
+    ) -> list[LeaderboardRankedEntry]:
         query = """
             WITH ranked_submissions AS (
                 SELECT
-                    s.name,
+                    s.file_name,
                     s.user_id,
-                    s.code,
                     s.submission_time,
-                    s.score,
-                    s.gpu_type,
-                    RANK() OVER (ORDER BY s.score ASC) as rank
-                FROM leaderboard.submission s
+                    r.score,
+                    r.runner,
+                    RANK() OVER (ORDER BY r.score ASC) as rank
+                FROM leaderboard.runs r
+                JOIN leaderboard.submission s ON r.submission_id = s.id
                 JOIN leaderboard.leaderboard l ON s.leaderboard_id = l.id
-                WHERE l.name = %s AND s.gpu_type = %s
+                WHERE l.name = %s AND r.runner = %s AND NOT r.secret
+                      AND r.score IS NOT NULL AND r.passed
             )
             SELECT * FROM ranked_submissions
             """
@@ -286,18 +385,87 @@ class LeaderboardDB:
         self.cursor.execute(query, args)
 
         return [
-            SubmissionItem(
+            LeaderboardRankedEntry(
                 leaderboard_name=leaderboard_name,
                 submission_name=submission[0],
                 user_id=submission[1],
-                code=submission[2],
-                submission_time=submission[3],
-                submission_score=submission[4],
+                submission_time=submission[2],
+                submission_score=submission[3],
                 gpu_type=gpu_name,
-                rank=submission[6],
+                rank=submission[5],
             )
             for submission in self.cursor.fetchall()
         ]
+
+    def generate_stats(self):
+        # code-level stats
+        self.cursor.execute(
+            """
+            SELECT COUNT(*) FROM leaderboard.code_files;
+            """
+        )
+        num_unique_codes = self.cursor.fetchone()[0]
+
+        # submission-level stats
+        self.cursor.execute(
+            """
+            SELECT
+                COUNT(*),
+                COUNT(*) FILTER (WHERE NOT done),
+                COUNT(DISTINCT user_id),
+                COUNT(*) FILTER (WHERE submission_time > %s)
+            FROM leaderboard.submission;
+            """,
+            (datetime.datetime.now() - datetime.timedelta(days=1),),
+        )
+        num_sub, num_sub_wait, num_users, num_last_day = self.cursor.fetchone()
+
+        # run-level stats
+        self.cursor.execute(
+            """
+            SELECT
+                COUNT(*),
+                COUNT(*) FILTER (WHERE passed),
+                COUNT(score),
+                COUNT(*) FILTER (WHERE secret)
+            FROM leaderboard.runs;
+            """
+        )
+        num_run, num_run_pass, num_scored, num_secret = self.cursor.fetchone()
+
+        # per-runner stats
+        self.cursor.execute(
+            """
+            SELECT
+                runner,
+                COUNT(*),
+                COUNT(*) FILTER (WHERE passed),
+                COUNT(score),
+                COUNT(*) FILTER (WHERE secret)
+            FROM leaderboard.runs
+            GROUP BY runner;
+            """
+        )
+
+        result = {
+            "num_unique_codes": num_unique_codes,
+            "num_submissions": num_sub,
+            "sub_waiting": num_sub_wait,
+            "num_users": num_users,
+            "sub_last_day": num_last_day,
+            "num_runs": num_run,
+            "runs_passed": num_run_pass,
+            "runs_scored": num_scored,
+            "runs_secret": num_secret,
+        }
+
+        for row in self.cursor.fetchall():
+            result[f"num_run.{row[0]}"] = row[1]
+            result[f"runs_passed.{row[0]}"] = row[2]
+            result[f"runs_scored.{row[0]}"] = row[3]
+            result[f"runs_secret.{row[0]}"] = row[4]
+
+        return result
 
 
 if __name__ == "__main__":

--- a/src/discord-cluster-manager/migrations/20250221_01_GA8ro-submission-collection.py
+++ b/src/discord-cluster-manager/migrations/20250221_01_GA8ro-submission-collection.py
@@ -1,0 +1,64 @@
+"""
+submission collection
+see https://github.com/gpu-mode/discord-cluster-manager/pull/171
+"""
+
+from yoyo import step
+
+__depends__ = {"20250202_01_YYS3Q-leaderboard-rename-reference-to-task"}
+
+steps = [
+    # Drop the old submissions table
+    step("DROP TABLE IF EXISTS leaderboard.submission;"),
+    step("DROP TABLE IF EXISTS leaderboard.code_files;"),
+    step("DROP TABLE IF EXISTS leaderboard.runs;"),
+
+    # create three new tables: One for deduplicating submitted code files,
+    # one for the submission itself, and one for individual runs
+    # The submission itself contains the code and the targeted leaderboard
+    # in the future, we could, e.g., avoid starting a runner if we know that
+    # the given code does not compile.
+    step("""
+         CREATE TABLE IF NOT EXISTS leaderboard.code_files (
+             id SERIAL PRIMARY KEY,
+             code TEXT NOT NULL,
+             hash TEXT GENERATED ALWAYS AS (encode(sha256(code::bytea), 'hex')) STORED
+         )
+         """),
+
+    step("""
+         CREATE TABLE IF NOT EXISTS leaderboard.submission (
+             id SERIAL PRIMARY KEY,
+             leaderboard_id INTEGER NOT NULL REFERENCES leaderboard.leaderboard(id),
+             file_name TEXT NOT NULL,
+             user_id TEXT NOT NULL,
+             code_id INTEGER NOT NULL REFERENCES leaderboard.code_files(id),
+             submission_time TIMESTAMP WITH TIME ZONE NOT NULL,
+             done BOOLEAN DEFAULT FALSE
+         )
+         """),
+
+    # the runs themselves contain information about a particular execution of that code.
+    # This includes start and end time
+    # Note that `score` can be NULL for non-ranked submissions
+    # `passed` indicates that the code compiled (if applicable), ran successfully,
+    #          and passed all testing
+    # `meta` contains all run "metadata", i.e., stdout and stderr, exit code etc
+    # `result` is the actual result returned to our evaluation system
+    step("""
+         CREATE TABLE IF NOT EXISTS leaderboard.runs (
+             id SERIAL PRIMARY KEY,
+             submission_id INTEGER NOT NULL REFERENCES leaderboard.submission(id),
+             start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+             end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+             mode TEXT NOT NULL,
+             secret BOOLEAN NOT NULL,
+             runner TEXT NOT NULL,
+             score NUMERIC,
+             passed BOOLEAN NOT NULL,
+             compilation JSONB,
+             meta JSONB,
+             result JSONB
+         )
+         """),
+]

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import re
 import subprocess
-from typing import Any, List, NotRequired, TypedDict
+from typing import Any, List, TypedDict
 
 import discord
 from consts import Language, SubmissionMode
@@ -173,17 +173,14 @@ class LeaderboardItem(TypedDict):
     gpu_types: List[str]
 
 
-class SubmissionItem(TypedDict):
+class LeaderboardRankedEntry(TypedDict):
     rank: int
     submission_name: str
     submission_time: datetime.datetime
     submission_score: float
     leaderboard_name: str
-    code: str
     user_id: int
     gpu_type: str
-    stdout: NotRequired[str]
-    profiler_output: NotRequired[str]
 
 
 def build_task_config(


### PR DESCRIPTION
This is a first attempt at reworking our database to enable detailed recording of submissions.
It split submissions into 3 tables:
1) code files. Here we store the actually submitted code. We have a hash column that allows us to quickly detect if the same code is submitted again, and in this case we just don't add it (e.g., multiple commands run with the same code, e.g., multiple benchmarks or multiple runs explicitly specifying different GPUs, or everyone testing our example script :)), no need to spam our DB with redundant data.
2) A table for an individual "submission", that is, one invocation of a bot command. This is associated with a code, and adds information about submission time, leaderboard and user. We also record a filename, and have a special flag "done" that starts out false and gets set to true once all jobs have finished. If we find lots of not-done submissions in our DB, we know something is wonky in the bot...
3) Actual runs. Executing the submission on a specific GPU, with a specific set of tests or benchmarks. We record start and end time of the actual run (might come in handy if we want to see if particular times of day have faster/slower GPUs, or if  we want to keep track of the average delay between submission and a job starting), which  mode (test, benchmark, profile, etc), which runner (this is essentially gpu type, but if we want to differentiate modal_h100 and github_h100, I think runner might be the better term); we  also keep all the other metadata (compilation result, running stdout/stderr, etc) in jsonb objects. Having _all_ runs, and all their start/end times in the  DB also enables us to figure out if particular users are overusing our hardware resources.

This is deliberately proactive in gathering as much data as possible, trying to minimize the information we throw away. For the leaderboard itself, we don't really need to keep track of submissions that don't have an associated score. Still, I'd rather record all submissions, and at some point start pruning the DB and throw away (user-invisible) things that aren't interesting. But first, let's see how much data this actually produces.

There is a new show-stats admin command, that quickly gives us an overview over the database:
```
num_unique_codes = 3
num_submissions = 5
sub_waiting = 0
num_users = 1
sub_last_day = 5
num_runs = 13
runs_passed = 13
runs_scored = 4
runs_secret = 6
num_run.L4 = 1
runs_passed.L4 = 1
runs_scored.L4 = 0
runs_secret.L4 = 0
num_run.T4 = 12
runs_passed.T4 = 12
runs_scored.T4 = 4
runs_secret.T4 = 6
total.xxxxxxxxxx = 0:00:00.019583
```
the last is my user-id, showing that I've used 19ms of runner time (excluding any setup/teardown, etc) in the last 24h.
this would show us the users with the highest runner usage.