### PR TITLE
error handling and logging

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -275,6 +275,11 @@ async def start_bot_and_api(debug_mode: bool):
     await asyncio.gather(bot_instance.start_bot(token), server.serve())
 
 
+def on_unhandled_exception(loop, context):
+    task: asyncio.Task = context['future']
+    logger.exception("Unhandled exception: %s", context['message'], exc_info=context['exception'])
+
+
 def main():
     init_environment()
 
@@ -284,7 +289,9 @@ def main():
 
     logger.info("Starting bot and API server...")
 
-    asyncio.run(start_bot_and_api(args.debug))
+    with asyncio.Runner(debug=args.debug) as runner:
+        runner.get_loop().set_exception_handler(on_unhandled_exception)
+        runner.run(start_bot_and_api(args.debug))
 
 
 if __name__ == "__main__":

--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -276,8 +276,7 @@ async def start_bot_and_api(debug_mode: bool):
 
 
 def on_unhandled_exception(loop, context):
-    task: asyncio.Task = context['future']
-    logger.exception("Unhandled exception: %s", context['message'], exc_info=context['exception'])
+    logger.exception("Unhandled exception: %s", context["message"], exc_info=context["exception"])
 
 
 def main():

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -17,6 +17,7 @@ from utils import (
     KernelBotError,
     send_discord_message,
     setup_logging,
+    with_error_handling,
 )
 
 if TYPE_CHECKING:
@@ -117,6 +118,7 @@ class AdminCog(commands.Cog):
         gpu=[app_commands.Choice(name=gpu.name, value=gpu.value) for gpu in GitHubGPU]
         + [app_commands.Choice(name=gpu.name, value=gpu.value) for gpu in ModalGPU]
     )
+    @with_error_handling
     async def leaderboard_create_local(
         self,
         interaction: discord.Interaction,
@@ -310,6 +312,7 @@ class AdminCog(commands.Cog):
 
     @discord.app_commands.describe(leaderboard_name="Name of the leaderboard")
     @discord.app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    @with_error_handling
     async def delete_leaderboard(self, interaction: discord.Interaction, leaderboard_name: str):
         is_admin = await self.admin_check(interaction)
         is_creator = await self.creator_check(interaction)
@@ -345,6 +348,7 @@ class AdminCog(commands.Cog):
 
         await interaction.response.send_modal(modal)
 
+    @with_error_handling
     async def stop(self, interaction: discord.Interaction):
         is_admin = await self.admin_check(interaction)
         if not is_admin:
@@ -360,6 +364,7 @@ class AdminCog(commands.Cog):
             interaction, "Bot will refuse all future submissions!", ephemeral=True
         )
 
+    @with_error_handling
     async def start(self, interaction: discord.Interaction):
         is_admin = await self.admin_check(interaction)
         if not is_admin:
@@ -380,6 +385,7 @@ class AdminCog(commands.Cog):
         repository_name="Name of the repository to load problems from (in format: user/repo)",
         branch="Which branch to pull from",
     )
+    @with_error_handling
     async def update_problems(
         self,
         interaction: discord.Interaction,
@@ -596,6 +602,7 @@ class AdminCog(commands.Cog):
         except Exception as e:
             logger.exception("Error updating problem set", exc_info=e)
 
+    @with_error_handling
     async def show_bot_stats(self, interaction: discord.Interaction):
         with self.bot.leaderboard_db as db:
             stats = db.generate_stats()
@@ -605,6 +612,7 @@ class AdminCog(commands.Cog):
             msg += "\n```"
             await send_discord_message(interaction, msg, ephemeral=True)
 
+    @with_error_handling
     async def resync(self, interaction: discord.Interaction):
         """Admin command to resync slash commands"""
         logger.info("Resyncing commands")

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -20,6 +20,7 @@ from utils import (
     get_user_from_id,
     send_discord_message,
     setup_logging,
+    with_error_handling,
 )
 
 if TYPE_CHECKING:
@@ -399,6 +400,7 @@ class LeaderboardSubmitCog(app_commands.Group):
         gpu="Select GPU. Leave empty for interactive or automatic selection.",
     )
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    @with_error_handling
     async def submit_test(
         self,
         interaction: discord.Interaction,
@@ -417,6 +419,7 @@ class LeaderboardSubmitCog(app_commands.Group):
         gpu="Select GPU. Leave empty for interactive or automatic selection.",
     )
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    @with_error_handling
     async def submit_bench(
         self,
         interaction: discord.Interaction,
@@ -437,6 +440,7 @@ class LeaderboardSubmitCog(app_commands.Group):
         gpu="Select GPU. Leave empty for interactive or automatic selection.",
     )
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    @with_error_handling
     async def submit_ranked(
         self,
         interaction: discord.Interaction,
@@ -722,6 +726,7 @@ class LeaderboardCog(commands.Cog):
     # |                           COMMANDS                                      |
     # --------------------------------------------------------------------------
 
+    @with_error_handling
     async def get_leaderboards(self, interaction: discord.Interaction):
         """Display all leaderboards in a table format"""
         await interaction.response.defer(ephemeral=True)
@@ -742,6 +747,7 @@ class LeaderboardCog(commands.Cog):
 
     @app_commands.describe(leaderboard_name="Name of the leaderboard")
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    @with_error_handling
     async def get_leaderboard_task(self, interaction: discord.Interaction, leaderboard_name: str):
         await interaction.response.defer(ephemeral=True)
 
@@ -768,6 +774,7 @@ class LeaderboardCog(commands.Cog):
     @app_commands.autocomplete(
         leaderboard_name=leaderboard_name_autocomplete, lang=lang_autocomplete
     )
+    @with_error_handling
     async def get_task_template(
         self, interaction: discord.Interaction, leaderboard_name: str, lang: str
     ):
@@ -813,6 +820,7 @@ class LeaderboardCog(commands.Cog):
 
     @discord.app_commands.describe(leaderboard_name="Name of the leaderboard")
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    @with_error_handling
     async def get_leaderboard_submissions(
         self,
         interaction: discord.Interaction,
@@ -822,6 +830,7 @@ class LeaderboardCog(commands.Cog):
 
     @discord.app_commands.describe(leaderboard_name="Name of the leaderboard")
     @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    @with_error_handling
     async def get_user_leaderboard_submissions(
         self,
         interaction: discord.Interaction,

--- a/src/discord-cluster-manager/cogs/misc_cog.py
+++ b/src/discord-cluster-manager/cogs/misc_cog.py
@@ -17,30 +17,6 @@ class BotManagerCog(commands.Cog):
         """Simple ping command to check if the bot is responsive"""
         await send_discord_message(interaction, "pong")
 
-    @app_commands.command(name="resync")
-    async def resync(self, interaction: discord.Interaction):
-        logger.info("Resyncing commands")
-
-        """Admin command to resync slash commands"""
-        if interaction.user.guild_permissions.administrator:
-            try:
-                await interaction.response.defer()
-                # Clear and resync
-                self.bot.tree.clear_commands(guild=interaction.guild)
-                await self.bot.tree.sync(guild=interaction.guild)
-                commands = await self.bot.tree.fetch_commands(guild=interaction.guild)
-                await send_discord_message(
-                    interaction,
-                    "Resynced commands:\n" + "\n".join([f"- /{cmd.name}" for cmd in commands]),
-                )
-            except Exception as e:
-                logger.error(f"Error in resync command: {str(e)}", exc_info=True)
-                await send_discord_message(interaction, f"Error: {str(e)}")
-        else:
-            await send_discord_message(
-                interaction, "You need administrator permissions to use this command"
-            )
-
     @app_commands.command(name="verifydb")
     async def verify_db(self, interaction: discord.Interaction):
         """Command to verify database connectivity"""

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -8,7 +8,7 @@ from discord.ext import commands
 from report import generate_report
 from run_eval import FullResult
 from task import LeaderboardTask
-from utils import build_task_config, send_discord_message, setup_logging
+from utils import build_task_config, send_discord_message, setup_logging, with_error_handling
 
 logger = setup_logging()
 
@@ -106,6 +106,7 @@ class SubmitCog(commands.Cog):
 
         return thread, result
 
+    @with_error_handling
     async def run_script(
         self,
         interaction: discord.Interaction,

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -79,11 +79,15 @@ class LeaderboardDB:
             self.cursor.close()
         if self.connection:
             self.connection.close()
+        self.cursor = None
+        self.connection = None
 
     def __enter__(self):
         """Context manager entry"""
-        self.connect()
-        return self
+        assert self.connection is None, "Nested db __enter__"
+        if self.connect():
+            return self
+        return None
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit"""

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -14,12 +14,13 @@ from env import (
     POSTGRES_PORT,
     POSTGRES_USER,
 )
-from psycopg2 import Error
 from run_eval import CompileResult, RunResult
 from task import LeaderboardTask
-from utils import LeaderboardItem, LeaderboardRankedEntry, LRUCache
+from utils import LeaderboardItem, LeaderboardRankedEntry, LRUCache, setup_logging
 
 leaderboard_name_cache = LRUCache(max_size=512)
+
+logger = setup_logging(__name__)
 
 
 async def leaderboard_name_autocomplete(
@@ -41,7 +42,7 @@ async def leaderboard_name_autocomplete(
         ]
         return leaderboard_name_cache[current]
     except Exception as e:
-        logging.exception("Error in leaderboard autocomplete", exc_info=e)
+        logger.exception("Error in leaderboard autocomplete", exc_info=e)
         return []
 
 
@@ -68,8 +69,8 @@ class LeaderboardDB:
             )
             self.cursor = self.connection.cursor()
             return True
-        except Error as e:
-            print(f"Error connecting to PostgreSQL: {e}")
+        except psycopg2.Error as e:
+            logger.exception("Error connecting to PostgreSQL", exc_info=e)
             return False
 
     def disconnect(self):

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -129,9 +129,9 @@ class LeaderboardDB:
                 raise KernelBotError(
                     "Error: Tried to create a leaderboard "
                     f'"{leaderboard["name"]}" that already exists.'
-                )
+                ) from e
             self.connection.rollback()  # Ensure rollback if error occurs
-            raise KernelBotError("Error in leaderboard creation.")
+            raise KernelBotError("Error in leaderboard creation.") from e
 
     def update_leaderboard(self, name, deadline, task):
         try:
@@ -161,7 +161,7 @@ class LeaderboardDB:
         except psycopg2.Error as e:
             logger.exception("Could not delete leaderboard %s.", leaderboard_name, exc_info=e)
             self.connection.rollback()
-            raise KernelBotError(f"Could not delete leaderboard {leaderboard_name}.")
+            raise KernelBotError(f"Could not delete leaderboard {leaderboard_name}.") from e
 
     def create_submission(
         self, leaderboard: str, file_name: str, user_id: int, code: str, time: datetime.datetime
@@ -288,7 +288,7 @@ class LeaderboardDB:
                 exc_info=e,
             )
             self.connection.rollback()  # Ensure rollback if error occurs
-            raise KernelBotError("Could not create leaderboard submission entry in database")
+            raise KernelBotError("Could not create leaderboard submission entry in database") from e
 
     def get_leaderboard_names(self) -> list[str]:
         self.cursor.execute("SELECT name FROM leaderboard.leaderboard")

--- a/src/discord-cluster-manager/ui/misc.py
+++ b/src/discord-cluster-manager/ui/misc.py
@@ -1,6 +1,6 @@
 import discord
 from discord import Interaction, SelectOption, ui
-from utils import send_discord_message
+from utils import KernelBotError, send_discord_message
 
 
 class GPUSelectionView(ui.View):
@@ -46,11 +46,12 @@ class DeleteConfirmationModal(ui.Modal, title="Confirm Deletion"):
             with self.db as db:
                 method = getattr(db, f"delete_{self.field_name}", None)
                 assert method is not None, f"Delete method for {self.field_name} not found in db"
-                err = method(self.field_value)
-                if err:
+                try:
+                    method(self.field_value)
+                except KernelBotError as e:
                     await send_discord_message(
                         interaction,
-                        "An error occurred while deleting the leaderboard.",
+                        str(e),
                         ephemeral=True,
                     )
                 else:

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -2,14 +2,14 @@ import datetime
 import logging
 import re
 import subprocess
-from typing import Any, List, TypedDict
+from typing import Any, List, TypedDict, Optional
 
 import discord
 from consts import Language, SubmissionMode
 from task import LeaderboardTask
 
 
-def setup_logging():
+def setup_logging(name: Optional[str] = None):
     """Configure and setup logging for the application"""
 
     formatter = logging.Formatter(
@@ -20,13 +20,23 @@ def setup_logging():
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
 
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger(name or __name__)
     logger.setLevel(logging.INFO)
 
     if not logger.handlers:
         logger.addHandler(console_handler)
 
     return logger
+
+
+class KernelBotError(Exception):
+    """
+    This class represents an Exception that has been sanitized,
+    i.e., whose message can be safely displayed to the user without
+    risk of leaking internal bot details.
+    """
+    def __init__(self, message):
+        super().__init__(message)
 
 
 def get_github_branch_name():
@@ -106,16 +116,6 @@ async def send_logs(thread: discord.Thread, logs: str) -> None:
         chunk_text = "\n".join(current_chunk)
         await thread.send(f"```\n{chunk_text}\n```")
 
-
-def extract_score(score_str: str) -> float:
-    """
-    Extract score from output logs and push to DB (kind of hacky).
-    """
-    match = re.search(r"score:\s*(-?\d+\.\d+)", score_str)
-    if match:
-        return float(match.group(1))
-    else:
-        return None
 
 
 class LRUCache:

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -1,7 +1,8 @@
 import datetime
+import functools
 import logging
 import subprocess
-from typing import Any, List, TypedDict, Optional
+from typing import Any, List, Optional, TypedDict
 
 import discord
 from consts import Language, SubmissionMode
@@ -26,6 +27,22 @@ def setup_logging(name: Optional[str] = None):
         logger.addHandler(console_handler)
 
     return logger
+
+
+def with_error_handling(f: callable):
+    @functools.wraps(f)
+    async def wrap(self, interaction: discord.Interaction, *args, **kwargs):
+        try:
+            await f(self, interaction, *args, **kwargs)
+        except Exception as e:
+            logging.exception("Unhandled exception %s", e, exc_info=e)
+            await send_discord_message(
+                interaction,
+                "An unexpected error occurred. Please report this to the developers.",
+                ephemeral=True,
+            )
+
+    return wrap
 
 
 class KernelBotError(Exception):

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import re
 import subprocess
 from typing import Any, List, TypedDict, Optional
 
@@ -35,6 +34,7 @@ class KernelBotError(Exception):
     i.e., whose message can be safely displayed to the user without
     risk of leaking internal bot details.
     """
+
     def __init__(self, message):
         super().__init__(message)
 
@@ -115,7 +115,6 @@ async def send_logs(thread: discord.Thread, logs: str) -> None:
     if current_chunk:
         chunk_text = "\n".join(current_chunk)
         await thread.send(f"```\n{chunk_text}\n```")
-
 
 
 class LRUCache:


### PR DESCRIPTION
some logging improvements
created a dedicated Exception subclass that we can use to communicate error messages across call boundaries. We don't want to use  the original exceptions, because we cannot actually display them to the user as we just don't know what kind of info might be visible in the exception object. For `KernelBotError`, the idea is that this indicates that the message of the exception object is intended specifically to be displayed to the user.

This avoids some cases where our db functions return strings only for the purpose of allowing error handling, and makes it harder to accidentally ignore such errors.

Additionally, contains some clean-up fixes, such as moving `resync` to the `admin` commands.