### PR TITLE
Fixes and dev improvements

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-from datetime import datetime
 
 import discord
 import uvicorn
@@ -226,7 +225,7 @@ class ClusterBot(commands.Bot):
         self, interaction: discord.Interaction, gpu_name: str, job_name: str
     ) -> discord.Thread:
         thread = await interaction.channel.create_thread(
-            name=f"{job_name} ({gpu_name}) - {datetime.now().strftime('%Y-%m-%d %H:%M')}",
+            name=f"{job_name} ({gpu_name})",
             type=discord.ChannelType.public_thread,
             auto_archive_duration=1440,
         )

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -313,7 +313,9 @@ class AdminCog(commands.Cog):
     @discord.app_commands.describe(leaderboard_name="Name of the leaderboard")
     @discord.app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
     @with_error_handling
-    async def delete_leaderboard(self, interaction: discord.Interaction, leaderboard_name: str):
+    async def delete_leaderboard(
+        self, interaction: discord.Interaction, leaderboard_name: str, force: bool = False
+    ):
         is_admin = await self.admin_check(interaction)
         is_creator = await self.creator_check(interaction)
         is_creator_of_leaderboard = await self.is_creator_check(interaction, leaderboard_name)
@@ -334,7 +336,9 @@ class AdminCog(commands.Cog):
                 )
                 return
 
-        modal = DeleteConfirmationModal("leaderboard", leaderboard_name, self.bot.leaderboard_db)
+        modal = DeleteConfirmationModal(
+            "leaderboard", leaderboard_name, self.bot.leaderboard_db, force=force
+        )
 
         forum_channel = self.bot.get_channel(self.bot.leaderboard_forum_id)
         threads = [thread for thread in forum_channel.threads if thread.name == leaderboard_name]

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -45,7 +45,7 @@ async def leaderboard_dir_autocomplete(
     current: str,
 ) -> list[discord.app_commands.Choice[str]]:
     """Return leaderboard names that match the current typed name"""
-    root = Path("examples")
+    root = Path(env.PROBLEM_DEV_DIR)
     return [
         discord.app_commands.Choice(name=x.name, value=x.name) for x in root.iterdir() if x.is_dir()
     ]
@@ -134,8 +134,8 @@ class AdminCog(commands.Cog):
             )
             return
 
-        directory = Path("examples") / directory
-        assert directory.resolve().is_relative_to(Path.cwd())
+        directory = Path(env.PROBLEM_DEV_DIR) / directory
+        assert directory.resolve().is_relative_to(Path.cwd() / env.PROBLEM_DEV_DIR)
         task = make_task(directory)
 
         # clearly mark this leaderboard as development-only

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -143,7 +143,7 @@ class AdminCog(commands.Cog):
 
         # create-local overwrites existing leaderboard
         with self.bot.leaderboard_db as db:
-            db.delete_leaderboard(leaderboard_name)
+            db.delete_leaderboard(leaderboard_name, force=True)
 
         if await self.create_leaderboard_in_db(
             interaction,

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -68,17 +68,6 @@ class LeaderboardSubmitCog(app_commands.Group):
                     else interaction.user.nick
                 )
 
-                if (
-                    "test" in result.runs
-                    and result.runs["test"].run.result.get("check", "") != "pass"
-                ):
-                    await discord_thread.send(
-                        f"Ran on {gpu.name} using {runner_name} runners!\n"
-                        + f"Leaderboard '{leaderboard_name}'.\n"
-                        + f"Submission title: {script.filename}.\n"
-                        + f"Submission user: {user_id}.\n"
-                    )
-
                 score = None
                 if "leaderboard" in result.runs:
                     score = 0.0

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -234,7 +234,7 @@ class LeaderboardSubmitCog(app_commands.Group):
                 await send_discord_message(
                     interaction,
                     "Contradicting leaderboard name specification. "
-                    "Submitting to {leaderboard_name}",
+                    f"Submitting to `{leaderboard_name}`",
                 )
             else:
                 leaderboard_name = info["leaderboard"]

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -273,9 +273,11 @@ class LeaderboardSubmitCog(app_commands.Group):
                 if g in task_gpus:
                     selected_gpus.append(g)
                 else:
+                    task_gpu_list = "".join([f" * {t}\n" for t in task_gpus])
                     await send_discord_message(
                         interaction,
-                        f"GPU {g} not available for `{leaderboard_name}`",
+                        f"GPU {g} not available for `{leaderboard_name}`\n"
+                        f"Choose on of: {task_gpu_list}",
                         ephemeral=True,
                     )
                     return -1

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -192,7 +192,7 @@ class VerifyRunCog(commands.Cog):
             logger.exception("Error in LB test", exc_info=E)
         finally:
             with self.bot.leaderboard_db as db:
-                db.delete_leaderboard(lb_name)
+                db.delete_leaderboard(lb_name, force=True)
 
         await send_discord_message(interaction, "Done")
 

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock
 
 import discord
+import env
+from cogs import admin_cog
 from cogs.github_cog import GitHubCog
 from cogs.leaderboard_cog import LeaderboardSubmitCog
 from cogs.modal_cog import ModalCog
@@ -145,9 +147,10 @@ class VerifyRunCog(commands.Cog):
             return False
 
     @app_commands.command(name="verify-task")
+    @app_commands.autocomplete(task=admin_cog.leaderboard_dir_autocomplete)
     async def verify_task(self, interaction: discord.Interaction, task: str):
-        directory = Path("examples") / task
-        if not directory.resolve().is_relative_to(Path.cwd() / "examples"):
+        directory = Path(env.PROBLEM_DEV_DIR) / task
+        if not directory.resolve().is_relative_to(Path.cwd() / env.PROBLEM_DEV_DIR):
             await send_discord_message(interaction, f"Invalid path {directory.resolve()}")
             return
         try:

--- a/src/discord-cluster-manager/env.py
+++ b/src/discord-cluster-manager/env.py
@@ -26,6 +26,9 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 GITHUB_REPO = os.getenv("GITHUB_REPO")
 PROBLEMS_REPO = os.getenv("PROBLEMS_REPO")
 
+# Directory that will be used for local problem development.
+PROBLEM_DEV_DIR = os.getenv("PROBLEM_DEV_DIR", "examples")
+
 # PostgreSQL-specific constants
 POSTGRES_HOST = os.getenv("POSTGRES_HOST")
 POSTGRES_DATABASE = os.getenv("POSTGRES_DATABASE")

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -111,7 +111,12 @@ class LeaderboardDB:
 
             leaderboard_id = self.cursor.fetchone()[0]
 
-            for gpu_type in leaderboard["gpu_types"]:
+            if isinstance(leaderboard["gpu_types"], str):
+                gpu_types = [leaderboard["gpu_types"]]
+            else:
+                gpu_types = leaderboard["gpu_types"]
+
+            for gpu_type in gpu_types:
                 self.cursor.execute(
                     """
                     INSERT INTO leaderboard.gpu_type (leaderboard_id, gpu_type)

--- a/src/discord-cluster-manager/report.py
+++ b/src/discord-cluster-manager/report.py
@@ -223,7 +223,7 @@ async def generate_report(thread: discord.Thread, result: FullResult, mode: Subm
             await _generate_test_report(thread, test_run)
             return
         else:
-            num_tests = int(test_run.result["test-count"])
+            num_tests = int(test_run.result.get("test-count", 0))
             for i in range(num_tests):
                 status = test_run.result.get(f"test.{i}.status", None)
                 if status is None:
@@ -242,7 +242,7 @@ async def generate_report(thread: discord.Thread, result: FullResult, mode: Subm
             await _generate_crash_report(thread, bench_run)
             return
 
-        num_bench = int(bench_run.result["benchmark-count"])
+        num_bench = int(bench_run.result.get("benchmark-count", 0))
 
         def log_one(base_name):
             status = bench_run.result.get(f"{base_name}.status")

--- a/src/discord-cluster-manager/report.py
+++ b/src/discord-cluster-manager/report.py
@@ -169,8 +169,6 @@ async def generate_report(thread: discord.Thread, result: FullResult, mode: Subm
 
     runs = result.runs
 
-    print(runs)
-
     # minimal error messages for private run
     if mode == SubmissionMode.PRIVATE:
         for r in runs.values():

--- a/src/discord-cluster-manager/ui/misc.py
+++ b/src/discord-cluster-manager/ui/misc.py
@@ -27,11 +27,13 @@ class GPUSelectionView(ui.View):
 
 
 class DeleteConfirmationModal(ui.Modal, title="Confirm Deletion"):
-    def __init__(self, field_name: str, field_value: str, db):
+    def __init__(self, field_name: str, field_value: str, db, force: bool = False):
         super().__init__()
         self.field_name = field_name
         self.field_value = field_value
         self.db = db
+        self.force = force
+
         placeholder = f"Type '{field_value}'"[:100]
         label = f"To delete, type '{field_value}'"[:45]
         self.confirmation = ui.TextInput(
@@ -47,7 +49,7 @@ class DeleteConfirmationModal(ui.Modal, title="Confirm Deletion"):
                 method = getattr(db, f"delete_{self.field_name}", None)
                 assert method is not None, f"Delete method for {self.field_name} not found in db"
                 try:
-                    method(self.field_value)
+                    method(self.field_value, force=self.force)
                 except KernelBotError as e:
                     await send_discord_message(
                         interaction,


### PR DESCRIPTION
A bunch of small fixes, and some improvements to smoothen the dev process (hopefully):

* A new verify-task command, that gets a task directory, creates a temporary leaderboard, submits test, benchmark, and ranked runs, then cleans up the LB again.

* delete_leaderboard has a `force` parameter that will delete all submissions to that leaderboard. That should **only** be used for dummy leaderboards, in other cases we want to preserve existing submissions.

* ability  to select base folder for problem development (defaults to `examples`)