### PR TITLE
Fix: fix update leaderboards

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,2 @@
+libcurl4-openssl-dev
 git


### PR DESCRIPTION
## Description

Fixes Update Lb command

TODO: support different upstreams?

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
