### PR TITLE
better verify

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -39,17 +39,18 @@ class ClusterBot(commands.Bot):
         super().__init__(intents=intents, command_prefix="!")
         self.debug_mode = debug_mode
 
-        # Create the run group
-        self.run_group = app_commands.Group(
-            name="run", description="Run jobs on different platforms"
-        )
+        # Create the run group for leaderboardless runs. Debugging only.
+        if self.debug_mode:
+            self.run_group = app_commands.Group(
+                name="run", description="Run jobs on different platforms"
+            )
+            self.tree.add_command(self.run_group)
 
         self.leaderboard_group = app_commands.Group(
             name="leaderboard", description="Leaderboard commands"
         )
         self.admin_group = app_commands.Group(name="admin", description="Admin commands")
 
-        self.tree.add_command(self.run_group)
         self.tree.add_command(self.admin_group)
         self.tree.add_command(self.leaderboard_group)
 

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -608,6 +608,15 @@ class AdminCog(commands.Cog):
 
     @with_error_handling
     async def show_bot_stats(self, interaction: discord.Interaction):
+        is_admin = await self.admin_check(interaction)
+        if not is_admin:
+            await send_discord_message(
+                interaction,
+                "You need to have Admin permissions to run this command",
+                ephemeral=True,
+            )
+            return
+
         with self.bot.leaderboard_db as db:
             stats = db.generate_stats()
             msg = """```"""

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -598,7 +598,7 @@ class AdminCog(commands.Cog):
             for entry in update_list:
                 with self.bot.leaderboard_db as db:
                     db.update_leaderboard(
-                        entry["name"], entry["deadline"], make_task(Path(entry["directory"]))
+                        entry["name"], entry["deadline"], make_task(root / entry["directory"])
                     )
 
             header += " DONE"

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -344,7 +344,7 @@ class LeaderboardSubmitCog(app_commands.Group):
             f"on GPUS: {', '.join([gpu.name for gpu in selected_gpus])} "
             f"using {', '.join({gpu.runner for gpu in selected_gpus})} runners succeeded!",
         )
-        return 0
+        return sub_id
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.channel_id != self.bot.leaderboard_submissions_id:

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -1,9 +1,10 @@
 from enum import Enum
-from typing import Optional, Tuple, Type
+from typing import Optional, Tuple, Type, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bot import ClusterBot
 
 import discord
-
-from bot import ClusterBot
 from consts import SubmissionMode
 from discord import app_commands
 from discord.ext import commands

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import Optional, Tuple, Type
 
 import discord
+
+from bot import ClusterBot
 from consts import SubmissionMode
 from discord import app_commands
 from discord.ext import commands
@@ -59,7 +61,7 @@ class SubmitCog(commands.Cog):
     """
 
     def __init__(self, bot, name: str, gpus: Type[Enum]):
-        self.bot = bot
+        self.bot: ClusterBot = bot
         self.name = name
 
         choices = [app_commands.Choice(name=c.name, value=c.value) for c in gpus]
@@ -81,9 +83,11 @@ class SubmitCog(commands.Cog):
             gpu_type=f"Choose the GPU type for {name}",
         )(run)
 
-        self.run_script = bot.run_group.command(
-            name=self.name.lower(), description=f"Run a script using {self.name}"
-        )(run)
+        # For now, direct (non-leaderboard) submissions are debug-only.
+        if self.bot.debug_mode:
+            self.run_script = bot.run_group.command(
+                name=self.name.lower(), description=f"Run a script using {self.name}"
+            )(run)
 
     async def submit_leaderboard(
         self,

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Tuple, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple, Type
 
 if TYPE_CHECKING:
     from bot import ClusterBot

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -17,7 +17,8 @@ from env import (
 )
 from run_eval import CompileResult, RunResult
 from task import LeaderboardTask
-from utils import KernelBotError, LeaderboardItem, LeaderboardRankedEntry, LRUCache, setup_logging
+from utils import KernelBotError, LeaderboardItem, LeaderboardRankedEntry, LRUCache, setup_logging, SubmissionItem, \
+    RunItem
 
 leaderboard_name_cache = LRUCache(max_size=512)
 
@@ -552,6 +553,45 @@ class LeaderboardDB:
             result[f"total.{row[0]}"] = row[1]
 
         return result
+
+    def get_submission_by_id(self, submission_id: int) -> Optional[SubmissionItem]:
+        query = """
+                SELECT s.leaderboard_id, lb.name, s.file_name, s.user_id, s.submission_time, s.done, c.code
+                FROM leaderboard.submission s
+                JOIN leaderboard.code_files c ON s.code_id = c.id
+                JOIN leaderboard.leaderboard lb ON s.leaderboard_id = lb.id
+                WHERE s.id = %s
+                """
+        self.cursor.execute(query, (submission_id,))
+        submission = self.cursor.fetchone()
+        if submission is None:
+            return None
+
+        # OK, now get the runs
+        query = """
+                SELECT start_time, end_time, mode, secret, runner, score, passed, compilation, meta, result
+                FROM leaderboard.runs
+                WHERE submission_id = %s
+                """
+        self.cursor.execute(query, (submission_id,))
+        runs = self.cursor.fetchall()
+
+        runs = [RunItem(
+            start_time=r[0],
+            end_time=r[1],
+            mode=r[2],
+            secret=r[3],
+            runner=r[4],
+            score=r[5],
+            passed=r[6],
+            compilation=r[7],
+            meta=r[8],
+            result=r[9]
+        ) for r in runs]
+
+        return SubmissionItem(leaderboard_id=submission[0], leaderboard_name=submission[1],
+                              file_name=submission[2], user_id=submission[3],
+                              submission_time=submission[4], done=submission[5], code=submission[6], runs=runs)
 
 
 if __name__ == "__main__":

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -199,6 +199,30 @@ class LeaderboardRankedEntry(TypedDict):
     gpu_type: str
 
 
+class RunItem(TypedDict):
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    mode: str
+    secret: bool
+    runner: str
+    score: Optional[float]
+    passed: bool
+    compilation: dict
+    meta: dict
+    result: dict
+
+
+class SubmissionItem(TypedDict):
+    leaderboard_id: int
+    leaderboard_name: str
+    file_name: str
+    user_id: int
+    submission_time: datetime.datetime
+    done: bool
+    code: str
+    runs: List[RunItem]
+
+
 def build_task_config(
     task: LeaderboardTask = None,
     submission_content: str = None,


### PR DESCRIPTION
Updates to `verify-task` : 
 * can decide to run only test/benchmark/ranked or all
 * looks for things to run in `solutions/{correct,wrong}` subfolders
 * automatically verifies that `correct`  solutions get `passed`  status, and `wrong` solutions don't