### PR TITLE
Feat: hide api url for now

### DIFF
--- a/src/discord-cluster-manager/cogs/misc_cog.py
+++ b/src/discord-cluster-manager/cogs/misc_cog.py
@@ -1,4 +1,5 @@
 import os
+from typing import TYPE_CHECKING
 
 import discord
 import psycopg2
@@ -7,11 +8,14 @@ from discord.ext import commands
 from env import DATABASE_URL
 from utils import send_discord_message, setup_logging
 
+if TYPE_CHECKING:
+    from ..bot import ClusterBot
+
 logger = setup_logging()
 
 
 class BotManagerCog(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: "ClusterBot"):
         self.bot = bot
 
     @app_commands.command(name="ping")
@@ -47,6 +51,12 @@ class BotManagerCog(commands.Cog):
 
     @app_commands.command(name="get-api-url")
     async def get_api_url(self, interaction: discord.Interaction):
+        if not self.bot.debug_mode:
+            await send_discord_message(
+                interaction, "Submission through the API are coming soon! Stay tuned... 👀"
+            )
+            return
+
         if not os.environ.get("HEROKU_APP_DEFAULT_DOMAIN_NAME"):
             await send_discord_message(
                 interaction,


### PR DESCRIPTION
## Description

Basically allows retrieving the api-url only if not debug mode, else sends a message that it's coming soon.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
