### PR TITLE
Fix: timeout issues

### DIFF
--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -382,12 +382,40 @@ def run_pytorch_script(  # noqa: C901
         # Write submission files to directory
         _create_files(sources)
 
+        # "compile" step: execute the script once. Will populate
+        # `load_inline`'s compile cache, so the actual runs will be faster.
+        try:
+            compile_run = run_program(["python", "submission.py"], seed=1)
+            if "-DTORCH_EXTENSION_NAME" in compile_run.stdout:
+                comp = CompileResult(
+                    nvcc_found=True,
+                    nvcc_version='',
+                    success=True,
+                    command=compile_run.command,
+                    stdout=compile_run.stdout,
+                    stderr=compile_run.stderr,
+                    exit_code=compile_run.exit_code
+                )
+            else:
+                comp = None
+        except subprocess.CalledProcessError as e:
+            # This step is purely optional, so we just go on
+            # if it fails
+            comp = CompileResult(nvcc_found=False,
+                                 nvcc_version='',
+                                 success=False,
+                                 command="python submission.py",
+                                 stdout=e.stdout,
+                                 stderr=e.stderr,
+                                 exit_code=e.returncode,
+                                 )
+
         run = run_single_evaluation(["python", main], **kwargs)
 
         return EvalResult(
             start=start,
             end=datetime.datetime.now(),
-            compilation=None,
+            compilation=comp,
             run=run,
         )
     finally:

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -382,11 +382,13 @@ def run_pytorch_script(  # noqa: C901
         # Write submission files to directory
         _create_files(sources)
 
+        run = run_single_evaluation(["python", main], **kwargs)
+
         return EvalResult(
             start=start,
             end=datetime.datetime.now(),
             compilation=None,
-            run=run_single_evaluation(["python", main], **kwargs),
+            run=run,
         )
     finally:
         for f in sources.keys():


### PR DESCRIPTION
## Description

Provides a compilation run to python solutions for inline Cuda. 

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [x] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
