### PR TITLE
stricter gpu scheduling for a100s and h100s

### DIFF
--- a/src/discord-cluster-manager/modal_runner_archs.py
+++ b/src/discord-cluster-manager/modal_runner_archs.py
@@ -4,11 +4,12 @@
 
 from modal_runner import app, cuda_image, modal_run_config
 
-gpus = ["T4", "L4", "A100", "H100"]
+gpus = ["T4", "L4", "A100-80GB", "H100!"]
 for gpu in gpus:
-    app.function(gpu=gpu, image=cuda_image, name=f"run_cuda_script_{gpu.lower()}", serialized=True)(
+    gpu_slug = gpu.lower().split("-")[0].strip('!')
+    app.function(gpu=gpu, image=cuda_image, name=f"run_cuda_script_{gpu_slug}", serialized=True)(
         modal_run_config
     )
     app.function(
-        gpu=gpu, image=cuda_image, name=f"run_pytorch_script_{gpu.lower()}", serialized=True
+        gpu=gpu, image=cuda_image, name=f"run_pytorch_script_{gpu_slug}", serialized=True
     )(modal_run_config)


### PR DESCRIPTION
## Description

The `app.function` parameter `gpu` will map work onto more than one GPU type when provided the strings `"A100"` and `"H100"`, which makes benchmarking noisier.

This PR changes those strings to `"A100-80GB"` and `"H100!"` (`!` meaning "strict") so that work is mapped onto only one GPU type.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
