### PR TITLE
Double timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules/
 package.json
 package-lock.json
 .ruff_cache/
+reference-kernels/
+yoyo.ini

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ yoyo-migrations
 ruff
 pre-commit
 better_profanity
+unittest
 
 # api
 fastapi[all] # install all to avoid random bugs

--- a/scripts/ci_test_python.py
+++ b/scripts/ci_test_python.py
@@ -101,12 +101,9 @@ def custom_kernel(data: input_t) -> output_t:
     time.sleep(5)
     return data
 """
-    from consts import Timeout
-    from unittest.mock import patch
 
-    with patch.object(Timeout, 'TEST', 2):
-        run = run_pytorch_helper({**files, "submission.py": sub}, test_timeout=Timeout.TEST)
-        assert run.success is False
-        assert run.stdout == ""
-        assert run.exit_code == ExitCode.TIMEOUT_EXPIRED
-        assert len(run.result) == 0
+    run = run_pytorch_helper({**files, "submission.py": sub}, test_timeout=2)
+    assert run.success is False
+    assert run.stdout == ""
+    assert run.exit_code == ExitCode.TIMEOUT_EXPIRED
+    assert len(run.result) == 0

--- a/scripts/ci_test_python.py
+++ b/scripts/ci_test_python.py
@@ -101,9 +101,12 @@ def custom_kernel(data: input_t) -> output_t:
     time.sleep(5)
     return data
 """
+    from consts import Timeout
+    from unittest.mock import patch
 
-    run = run_pytorch_helper({**files, "submission.py": sub}, test_timeout=2)
-    assert run.success is False
-    assert run.stdout == ""
-    assert run.exit_code == ExitCode.TIMEOUT_EXPIRED
-    assert len(run.result) == 0
+    with patch.object(Timeout, 'TEST', 2):
+        run = run_pytorch_helper({**files, "submission.py": sub}, test_timeout=Timeout.TEST)
+        assert run.success is False
+        assert run.stdout == ""
+        assert run.exit_code == ExitCode.TIMEOUT_EXPIRED
+        assert len(run.result) == 0

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -2,6 +2,10 @@ import dataclasses
 from enum import Enum, IntEnum
 from typing import Type
 
+class Timeout(IntEnum):
+    TEST = 60
+    BENCHMARK = 120
+    LEADERBOARD = 180
 
 class GPUType(Enum):
     NVIDIA = "nvidia_workflow.yml"

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -8,6 +8,8 @@ class Timeout(IntEnum):
     BENCHMARK = 120
     RANKED = 180
     COMPILE = 120
+    SCRIPT = 120
+
 
 class GPUType(Enum):
     NVIDIA = "nvidia_workflow.yml"

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -2,6 +2,7 @@ import dataclasses
 from enum import Enum, IntEnum
 from typing import Type
 
+
 class Timeout(IntEnum):
     TEST = 60
     BENCHMARK = 120

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -6,7 +6,8 @@ from typing import Type
 class Timeout(IntEnum):
     TEST = 60
     BENCHMARK = 120
-    LEADERBOARD = 180
+    RANKED = 180
+    COMPILE = 120
 
 class GPUType(Enum):
     NVIDIA = "nvidia_workflow.yml"

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -181,7 +181,7 @@ def compile_cuda_script(  # # noqa: C901
 
     print_("[Compiling]")
     try:
-        compile_process = subprocess.run(command, capture_output=True, text=True, check=True)
+        compile_process = subprocess.run(command, capture_output=True, text=True, check=True, timeout=Timeout.COMPILE)
     except subprocess.CalledProcessError as e:
         return CompileResult(
             nvcc_found=True,
@@ -289,7 +289,7 @@ def run_single_evaluation(
             return run_program(call + [mode, bench_file.name], seed=seed, timeout=timeout)
     else:
         assert mode == "script"
-        return run_program(call, seed=seed)
+        return run_program(call, seed=seed, timeout=Timeout.SCRIPT)
 
 
 def run_cuda_script(  # # noqa: C901
@@ -381,7 +381,7 @@ def run_pytorch_script(  # noqa: C901
         # "compile" step: execute the script once. Will populate
         # `load_inline`'s compile cache, so the actual runs will be faster.
         try:
-            compile_run = run_program(["python", "submission.py"], seed=1)
+            compile_run = run_program(["python", "submission.py"], seed=1, timeout=Timeout.COMPILE)
             if "-DTORCH_EXTENSION_NAME" in compile_run.stdout:
                 comp = CompileResult(
                     nvcc_found=True,

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -204,7 +204,7 @@ def compile_cuda_script(  # # noqa: C901
     )
 
 
-def run_program(args: list[str], seed: int, timeout: int = Timeout.TEST) -> RunResult:
+def run_program(args: list[str], seed: int, timeout: int) -> RunResult:
     print("[Running]")
     # set up a pipe so the tester can communicate its verdict with us
     env = os.environ.copy()
@@ -267,6 +267,9 @@ def run_single_evaluation(
     mode: str,
     tests: Optional[str] = None,
     benchmarks: Optional[str] = None,
+    test_timeout: int = Timeout.TEST,
+    benchmark_timeout: int = Timeout.BENCHMARK,
+    ranked_timeout: int = Timeout.RANKED,
     seed: Optional[int] = 42,
 ) -> RunResult:
     """
@@ -277,9 +280,9 @@ def run_single_evaluation(
         with tempfile.NamedTemporaryFile("w") as tests_file:
             tests_file.write(tests)
             tests_file.flush()
-            return run_program(call + [mode, tests_file.name], seed=seed, timeout=Timeout.TEST)
+            return run_program(call + [mode, tests_file.name], seed=seed, timeout=test_timeout)
     elif mode in ["benchmark", "profile", "leaderboard"]:
-        timeout = Timeout.LEADERBOARD if mode == "leaderboard" else Timeout.BENCHMARK
+        timeout = ranked_timeout if mode == "leaderboard" else benchmark_timeout
         with tempfile.NamedTemporaryFile("w") as bench_file:
             bench_file.write(benchmarks)
             bench_file.flush()

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -279,11 +279,7 @@ def run_single_evaluation(
             tests_file.flush()
             return run_program(call + [mode, tests_file.name], seed=seed, timeout=Timeout.TEST)
     elif mode in ["benchmark", "profile", "leaderboard"]:
-        timeout = {
-            "benchmark": Timeout.BENCHMARK,
-            "profile": Timeout.BENCHMARK,
-            "leaderboard": Timeout.LEADERBOARD,
-        }[mode]
+        timeout = Timeout.LEADERBOARD if mode == "leaderboard" else Timeout.BENCHMARK
         with tempfile.NamedTemporaryFile("w") as bench_file:
             bench_file.write(benchmarks)
             bench_file.flush()

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -181,7 +181,8 @@ def compile_cuda_script(  # # noqa: C901
 
     print_("[Compiling]")
     try:
-        compile_process = subprocess.run(command, capture_output=True, text=True, check=True, timeout=Timeout.COMPILE)
+        compile_process = subprocess.run(command, capture_output=True,
+                                          text=True, check=True, timeout=Timeout.COMPILE)
     except subprocess.CalledProcessError as e:
         return CompileResult(
             nvcc_found=True,


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes in this pull request.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
