### PR TITLE
Add amd docker and daily publisher.

### DIFF
--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -60,7 +60,9 @@ jobs:
     - name: Run script
       shell: bash
       run: |
-        source ${VENV_DIR}/bin/activate
+        if [[ "${{ github.event.inputs.runner }}" == "amdgpu-mi250-x86-64" ]]; then
+          source ${VENV_DIR}/bin/activate
+        fi
         python3 .github/workflows/runner.py
         cat result.json  # Debug: show output
 

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -40,15 +40,15 @@ jobs:
       run: |
         if [[ "${{ github.event.inputs.runner }}" == "amdgpu-mi250-x86-64" ]]; then
           echo "VENV_DIR=/groups/aig_sharks/pytorch_venv" >> $GITHUB_ENV
-        else
-          echo "VENV_DIR==$GITHUB_WORKSPACE" >> $GITHUB_ENV
         fi
 
     - name: Setup Virtual Environment and Install Dependencies
       shell: bash
       run: |
-        python -m venv ${VENV_DIR}
-        source ${VENV_DIR}/bin/activate
+        if [[ "${{ github.event.inputs.runner }}" == "amdgpu-mi250-x86-64" ]]; then
+          python -m venv ${VENV_DIR}
+          source ${VENV_DIR}/bin/activate
+        fi
         pip install --upgrade pip
         if [[ -n "${{ github.event.inputs.requirements }}" ]]; then
           cat > "requirements.txt" <<'EOL'

--- a/.github/workflows/publish_amd_docker.yml
+++ b/.github/workflows/publish_amd_docker.yml
@@ -1,0 +1,43 @@
+name: Publish ghascale amd image
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * *'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gpu-mode/amd-runner
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `PUBLISH_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.PUBLISH_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: docker/amd-docker.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_amd_docker.yml
+++ b/.github/workflows/publish_amd_docker.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: amdgpu-mi300-x86-64
+    runs-on: amdgpu-mi250-x86-64
     # Sets the permissions granted to the `PUBLISH_TOKEN` for the actions in this job.
     permissions:
       contents: read

--- a/.github/workflows/publish_amd_docker.yml
+++ b/.github/workflows/publish_amd_docker.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: amdgpu-mi300-x86-64
     # Sets the permissions granted to the `PUBLISH_TOKEN` for the actions in this job.
     permissions:
       contents: read

--- a/.github/workflows/publish_amd_docker.yml
+++ b/.github/workflows/publish_amd_docker.yml
@@ -1,6 +1,5 @@
 name: Publish ghascale amd image
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '30 5 * * *'

--- a/.github/workflows/publish_amd_docker.yml
+++ b/.github/workflows/publish_amd_docker.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: amdgpu-mi250-x86-64
+    runs-on: amd-docker
     # Sets the permissions granted to the `PUBLISH_TOKEN` for the actions in this job.
     permissions:
       contents: read

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -1,0 +1,37 @@
+FROM ghcr.io/actions/actions-runner:latest
+
+RUN sudo apt-get update -y \
+    && sudo apt-get install -y software-properties-common \
+    && sudo add-apt-repository -y ppa:git-core/ppa \
+    && sudo apt-get update -y \
+    && sudo apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    jq \
+    sudo \
+    unzip \
+    zip \
+    cmake \
+    ninja-build \
+    clang \
+    lld \
+    wget \
+    psmisc \
+    python3.10-venv \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
+    sudo apt-get install git-lfs
+
+RUN sudo groupadd -g 109 render
+
+RUN sudo apt update -y \
+    && sudo apt install -y "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
+    && sudo usermod -a -G render,video runner \
+    && wget https://repo.radeon.com/amdgpu-install/6.3.3/ubuntu/jammy/amdgpu-install_6.3.60303-1_all.deb \
+    && sudo apt install -y ./amdgpu-install_6.3.60303-1_all.deb \
+    && sudo apt update -y \
+    && sudo apt install -y rocm-dev
+
+RUN pip install torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -29,9 +29,9 @@ RUN sudo groupadd -g 109 render
 RUN sudo apt update -y \
     && sudo apt install -y "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
     && sudo usermod -a -G render,video runner \
-    && wget https://repo.radeon.com/amdgpu-install/6.3.3/ubuntu/jammy/amdgpu-install_6.3.60303-1_all.deb \
-    && sudo apt install -y ./amdgpu-install_6.3.60303-1_all.deb \
+    && wget https://repo.radeon.com/amdgpu-install/6.2.2/ubuntu/jammy/amdgpu-install_6.2.60202-1_all.deb \
+    && sudo apt install -y ./amdgpu-install_6.2.60202-1_all.deb \
     && sudo apt update -y \
     && sudo apt install -y rocm-dev
 
-RUN pip install torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+RUN pip install torch --index-url https://download.pytorch.org/whl/rocm6.2.4


### PR DESCRIPTION
## Description

This commit adds a docker that is used as the base for the mi300 runners. This is to help with cold start times (including torch rocm now) and provide a centralized source of truth that is published daily and automatically picked up by mi300 runners every time there is a publish

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
