### PR TITLE
Feat: add required deps to the amd docker image

### DIFF
--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -35,3 +35,11 @@ RUN sudo apt update -y \
     && sudo apt install -y rocm-dev
 
 RUN pip install torch --index-url https://download.pytorch.org/whl/rocm6.2.4
+
+RUN pip install \
+    ninja \
+    numpy \
+    packaging \
+    wheel \
+    triton \
+    tinygrad


### PR DESCRIPTION
## Description

Should not break anything on main server, though probably need to fix the workflow to be manually runnable?

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
