### PR TITLE
Improvements to submission UI

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -223,16 +223,6 @@ class ClusterBot(commands.Bot):
 
         await self._setup_leaderboards()
 
-    async def create_thread(
-        self, interaction: discord.Interaction, gpu_name: str, job_name: str
-    ) -> discord.Thread:
-        thread = await interaction.channel.create_thread(
-            name=f"{job_name} ({gpu_name})",
-            type=discord.ChannelType.public_thread,
-            auto_archive_duration=1440,
-        )
-        return thread
-
     async def send_chunked_message(self, channel, content: str, code_block: bool = True):
         """
         Send a long message in chunks to avoid Discord's message length limit

--- a/src/discord-cluster-manager/cogs/github_cog.py
+++ b/src/discord-cluster-manager/cogs/github_cog.py
@@ -1,10 +1,11 @@
 import datetime
 import json
 
-from cogs.submit_cog import ProgressReporter, SubmitCog
+from cogs.submit_cog import SubmitCog
 from consts import AMD_REQUIREMENTS, NVIDIA_REQUIREMENTS, GitHubGPU, GPUType
 from discord import app_commands
 from github_runner import GitHubRun
+from report import RunProgressReporter
 from run_eval import CompileResult, EvalResult, FullResult, RunResult, SystemInfo
 from utils import setup_logging
 
@@ -19,7 +20,7 @@ class GitHubCog(SubmitCog):
         return None
 
     async def _run_submission(
-        self, config: dict, gpu_type: GPUType, status: ProgressReporter
+        self, config: dict, gpu_type: GPUType, status: RunProgressReporter
     ) -> FullResult:
         selected_gpu = GPUType.AMD if gpu_type.value == "amd" else GPUType.NVIDIA
 
@@ -91,7 +92,7 @@ class GitHubCog(SubmitCog):
         system = SystemInfo(**data.get("system", {}))
         return FullResult(success=True, error="", runs=runs, system=system)
 
-    async def wait_callback(self, run: GitHubRun, status: ProgressReporter):
+    async def wait_callback(self, run: GitHubRun, status: RunProgressReporter):
         await status.update(
             f"⏳ Workflow [{run.run_id}]({run.html_url}): {run.status} "
             f"({run.elapsed_time.total_seconds():.1f}s)"

--- a/src/discord-cluster-manager/cogs/modal_cog.py
+++ b/src/discord-cluster-manager/cogs/modal_cog.py
@@ -1,9 +1,10 @@
 import asyncio
 
 import modal
-from cogs.submit_cog import ProgressReporter, SubmitCog
+from cogs.submit_cog import SubmitCog
 from consts import GPU_TO_SM, MODAL_CUDA_INCLUDE_DIRS, GPUType, ModalGPU
 from discord import app_commands
+from report import RunProgressReporter
 from run_eval import FullResult
 from utils import setup_logging
 
@@ -18,7 +19,7 @@ class ModalCog(SubmitCog):
         return GPU_TO_SM[gpu_type.value.upper()]
 
     async def _run_submission(
-        self, config: dict, gpu_type: GPUType, status: ProgressReporter
+        self, config: dict, gpu_type: GPUType, status: RunProgressReporter
     ) -> FullResult:
         loop = asyncio.get_event_loop()
         if config["lang"] == "cu":
@@ -26,9 +27,9 @@ class ModalCog(SubmitCog):
         func_type = "pytorch" if config["lang"] == "py" else "cuda"
         func_name = f"run_{func_type}_script_{gpu_type.value.lower()}"
 
-        logger.info(f"Starting modal run using {func_name}")
+        logger.info(f"Starting Modal run using {func_name}")
 
-        await status.push("⏳ Waiting for modal run to finish...")
+        await status.push("⏳ Waiting for Modal run to finish...")
 
         result = await loop.run_in_executor(
             None,


### PR DESCRIPTION
Create _private_ threads for detailed submission info, link to them in an ephemeral summary message that tracks the status of the entire submission.
 +some additional refactoring

This is currently deployed on dev, so you can test it on the staging bot.