### PR TITLE
Keeping track of forum thread

### DIFF
--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -106,8 +106,8 @@ class LeaderboardDB:
         try:
             self.cursor.execute(
                 """
-                INSERT INTO leaderboard.leaderboard (name, deadline, task, creator_id)
-                VALUES (%s, %s, %s, %s)
+                INSERT INTO leaderboard.leaderboard (name, deadline, task, creator_id, forum_id)
+                VALUES (%s, %s, %s, %s, %s)
                 RETURNING id
                 """,
                 (
@@ -115,6 +115,7 @@ class LeaderboardDB:
                     leaderboard["deadline"],
                     leaderboard["task"].to_str(),
                     leaderboard["creator_id"],
+                    leaderboard["forum_id"],
                 ),
             )
 
@@ -417,7 +418,7 @@ class LeaderboardDB:
     def get_leaderboard(self, leaderboard_name: str) -> LeaderboardItem | None:
         self.cursor.execute(
             """
-            SELECT id, name, deadline, task, creator_id
+            SELECT id, name, deadline, task, creator_id, forum_id
             FROM leaderboard.leaderboard
             WHERE name = %s
             """,
@@ -434,6 +435,7 @@ class LeaderboardDB:
                 deadline=res[2],
                 task=task,
                 creator_id=res[4],
+                forum_id=res[5],
             )
         else:
             return None

--- a/src/discord-cluster-manager/migrations/20250316_01_5oMi3-remember-forum-id.py
+++ b/src/discord-cluster-manager/migrations/20250316_01_5oMi3-remember-forum-id.py
@@ -1,0 +1,16 @@
+"""
+remember forum_id for leaderboard:
+    makes it much easier for us to keep track of the corresponding thread;
+    we don't have to rely on name matching
+"""
+
+from yoyo import step
+
+__depends__ = {"20250304_01_DzORz-collect-system-information-for-each-run"}
+
+steps = [
+    step(
+        "ALTER TABLE leaderboard.leaderboard ADD COLUMN forum_id BIGINT NOT NULL DEFAULT -1",
+    ),
+    step("ALTER TABLE leaderboard.leaderboard ALTER COLUMN forum_id DROP DEFAULT;"),
+]

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -184,11 +184,13 @@ class LRUCache:
 
 
 class LeaderboardItem(TypedDict):
+    id: int
     name: str
     creator_id: int
     deadline: datetime.datetime
     task: LeaderboardTask
     gpu_types: List[str]
+    forum_id: int
 
 
 class LeaderboardRankedEntry(TypedDict):


### PR DESCRIPTION
This PR keeps track of the id of the forum thread associated with a leaderboard.
In itself, this isn't very useful yet, but in the future, it lets us communicate more easily in a leaderboard-specific channel.