### PR TITLE
Update amd docker to latest deps.

### DIFF
--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -28,13 +28,14 @@ RUN sudo groupadd -g 109 render
 
 RUN sudo apt update -y \
     && sudo apt install -y "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
+    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
     && sudo usermod -a -G render,video runner \
-    && wget https://repo.radeon.com/amdgpu-install/6.2.2/ubuntu/jammy/amdgpu-install_6.2.60202-1_all.deb \
-    && sudo apt install -y ./amdgpu-install_6.2.60202-1_all.deb \
+    && wget https://repo.radeon.com/amdgpu-install/6.3.1/ubuntu/jammy/amdgpu-install_6.3.60301-1_all.deb \
+    && sudo apt install -y ./amdgpu-install_6.3.60301-1_all.deb \
     && sudo apt update -y \
     && sudo apt install -y rocm-dev
 
-RUN pip install torch --index-url https://download.pytorch.org/whl/rocm6.2.4
+RUN pip install torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
 
 RUN pip install \
     ninja \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -37,12 +37,11 @@ RUN sudo apt update -y \
 
 RUN pip install --upgrade pip
 
-RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
 
 RUN pip install \
     ninja \
     numpy \
     packaging \
     wheel \
-    triton \
     tinygrad

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -35,7 +35,9 @@ RUN sudo apt update -y \
     && sudo apt update -y \
     && sudo apt install -y rocm-dev
 
-RUN pip install torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+RUN pip install --upgrade pip
+
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
 
 RUN pip install \
     ninja \


### PR DESCRIPTION
## Description

Update amd docker to rocm 6.3.1

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
