### PR TITLE
Add all of rocm.

### DIFF
--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/actions/actions-runner:latest
 
+ENV CXX=clang++
+
 RUN sudo apt-get update -y \
     && sudo apt-get install -y software-properties-common \
     && sudo add-apt-repository -y ppa:git-core/ppa \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -33,7 +33,7 @@ RUN sudo apt update -y \
     && wget https://repo.radeon.com/amdgpu-install/6.3.1/ubuntu/jammy/amdgpu-install_6.3.60301-1_all.deb \
     && sudo apt install -y ./amdgpu-install_6.3.60301-1_all.deb \
     && sudo apt update -y \
-    && sudo apt install -y rocm-dev
+    && sudo apt install -y rocm
 
 RUN pip install --upgrade pip
 


### PR DESCRIPTION
## Description

Add full rocm to add support for deps like rocThrust to support hip inline.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
