### PR TITLE
enable comments in HIP template

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -326,7 +326,7 @@ async def lang_autocomplete(
 def add_header_to_template(lang: str, lb: LeaderboardItem):
     template_file = lb["task"].templates[lang]
 
-    comment_char = {"CUDA": "//", "Python": "#", "Triton": "#"}[lang]
+    comment_char = {"CUDA": "//", "Python": "#", "Triton": "#", "HIP": "#"}[lang]
 
     description_comment = [
         f"{comment_char} > {line}" for line in lb["task"].description.splitlines()


### PR DESCRIPTION
We'll need to distinguish between inline and non-inline hip at some point, but for now, this unblocks us