### PR TITLE
Add aiter install to amd docker.

### DIFF
--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -24,11 +24,6 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-
     - name: Create input files
       shell: bash
       run: |

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -9,7 +9,7 @@ on:
       runner:
         description: 'AMD runner to run workflow on'
         required: true
-        default: "amdgpu-mi300-x86-64-test"
+        default: "amdgpu-mi300-x86-64"
         type: string
       requirements:
         description: 'Contents for a requirements.txt file'

--- a/.github/workflows/amd_workflow.yml
+++ b/.github/workflows/amd_workflow.yml
@@ -9,7 +9,7 @@ on:
       runner:
         description: 'AMD runner to run workflow on'
         required: true
-        default: "amdgpu-mi300-x86-64"
+        default: "amdgpu-mi300-x86-64-test"
         type: string
       requirements:
         description: 'Contents for a requirements.txt file'

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -37,15 +37,6 @@ RUN sudo apt update -y \
     && sudo apt update -y \
     && sudo apt install -y rocm
 
-RUN sudo apt update -y \
-    && sudo apt install -y "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
-    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
-    && sudo usermod -a -G render,video runner \
-    && wget https://repo.radeon.com/amdgpu-install/6.3.1/ubuntu/jammy/amdgpu-install_6.3.60301-1_all.deb \
-    && sudo apt install -y ./amdgpu-install_6.3.60301-1_all.deb \
-    && sudo apt update -y \
-    && sudo apt install -y rocm
-
 RUN pip install --upgrade pip
 
 RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
@@ -53,7 +44,7 @@ RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://dow
 RUN git clone --recursive https://github.com/ROCm/aiter.git \
     && cd aiter \
     && pip install -r requirements.txt \
-    && python3 setup.py develop
+    && sudo python3 setup.py develop
 
 RUN pip install \
     ninja \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -44,6 +44,7 @@ RUN sudo pip install --no-cache-dir pytorch-triton-rocm torch --index-url https:
 
 RUN git clone --recursive https://github.com/ROCm/aiter.git \
     && cd aiter \
+    && git checkout 1d88633958236e942cba3c283864282f7af3ebc5 \
     && sudo pip install -r requirements.txt \
     && sudo python3 setup.py develop
 

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -23,7 +23,7 @@ RUN sudo apt-get update -y \
     python3.10-venv \
     && sudo rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y python3 python3-pip python-is-python3
+RUN sudo apt-get update && sudo apt-get install -y python3.10 python3-pip python-is-python3 python3-setuptools python3-wheel libpython3.10
 
 RUN python --version && python3 --version
 
@@ -34,7 +34,6 @@ RUN sudo groupadd -g 109 render
 
 RUN sudo apt update -y \
     && sudo apt install -y "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
-    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
     && sudo usermod -a -G render,video runner \
     && wget https://repo.radeon.com/amdgpu-install/6.3.1/ubuntu/jammy/amdgpu-install_6.3.60301-1_all.deb \
     && sudo apt install -y ./amdgpu-install_6.3.60301-1_all.deb \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -48,6 +48,7 @@ RUN sudo apt update -y \
 
 RUN git clone --recursive https://github.com/ROCm/aiter.git \
     && cd aiter \
+    && pip install -r requirements.txt \
     && python3 setup.py develop
 
 RUN pip install --upgrade pip

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/actions/actions-runner:latest
 
 ENV CXX=clang++
+USER root
 
 RUN sudo apt-get update -y \
     && sudo apt-get install -y software-properties-common \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -23,6 +23,10 @@ RUN sudo apt-get update -y \
     python3.10-venv \
     && sudo rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && apt-get install -y python3 python3-pip python-is-python3
+
+RUN python --version && python3 --version
+
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
     sudo apt-get install git-lfs
 

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -1,7 +1,6 @@
 FROM ghcr.io/actions/actions-runner:latest
 
 ENV CXX=clang++
-USER root
 
 RUN sudo apt-get update -y \
     && sudo apt-get install -y software-properties-common \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -25,8 +25,6 @@ RUN sudo apt-get update -y \
 
 RUN sudo apt-get update && sudo apt-get install -y python3.10 python3-pip python-is-python3 python3-setuptools python3-wheel libpython3.10
 
-RUN python --version && python3 --version
-
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
     sudo apt-get install git-lfs
 

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -38,16 +38,16 @@ RUN sudo apt update -y \
     && sudo apt update -y \
     && sudo apt install -y rocm
 
-RUN pip install --upgrade pip
+RUN sudo pip install --upgrade pip
 
-RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+RUN sudo pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
 
 RUN git clone --recursive https://github.com/ROCm/aiter.git \
     && cd aiter \
-    && pip install -r requirements.txt \
-    && python3 setup.py develop
+    && sudo pip install -r requirements.txt \
+    && sudo python3 setup.py develop
 
-RUN pip install \
+RUN sudo pip install \
     ninja \
     numpy \
     packaging \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -37,6 +37,19 @@ RUN sudo apt update -y \
     && sudo apt update -y \
     && sudo apt install -y rocm
 
+RUN sudo apt update -y \
+    && sudo apt install -y "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
+    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
+    && sudo usermod -a -G render,video runner \
+    && wget https://repo.radeon.com/amdgpu-install/6.3.1/ubuntu/jammy/amdgpu-install_6.3.60301-1_all.deb \
+    && sudo apt install -y ./amdgpu-install_6.3.60301-1_all.deb \
+    && sudo apt update -y \
+    && sudo apt install -y rocm
+
+RUN git clone --recursive https://github.com/ROCm/aiter.git \
+    && cd aiter \
+    && python3 setup.py develop
+
 RUN pip install --upgrade pip
 
 RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -46,14 +46,14 @@ RUN sudo apt update -y \
     && sudo apt update -y \
     && sudo apt install -y rocm
 
+RUN pip install --upgrade pip
+
+RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+
 RUN git clone --recursive https://github.com/ROCm/aiter.git \
     && cd aiter \
     && pip install -r requirements.txt \
     && python3 setup.py develop
-
-RUN pip install --upgrade pip
-
-RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
 
 RUN pip install \
     ninja \

--- a/docker/amd-docker.Dockerfile
+++ b/docker/amd-docker.Dockerfile
@@ -45,7 +45,7 @@ RUN pip install --no-cache-dir pytorch-triton-rocm torch --index-url https://dow
 RUN git clone --recursive https://github.com/ROCm/aiter.git \
     && cd aiter \
     && pip install -r requirements.txt \
-    && sudo python3 setup.py develop
+    && python3 setup.py develop
 
 RUN pip install \
     ninja \


### PR DESCRIPTION
## Description

This commit removes the python setup step from the workflow in every run, and we move it to the docker instead. This brings startup times to < 3 seconds, and it also allows us to install aiter (hash: 1d88633958236e942cba3c283864282f7af3ebc5) cleanly as it is a `python setup.py` install which installs on the docker's installed python so we now use it in the job instead of relying on the github python setup.

Tested here: https://github.com/gpu-mode/discord-cluster-manager/actions/runs/14635638085

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
