### PR TITLE
Fix: move getting trigger time after io calls

### DIFF
--- a/src/discord-cluster-manager/launchers/github.py
+++ b/src/discord-cluster-manager/launchers/github.py
@@ -157,7 +157,6 @@ class GitHubRun:
 
         Returns: Whether the run was successfully triggered,
         """
-        trigger_time = datetime.datetime.now(datetime.timezone.utc)
         try:
             workflow = await asyncio.to_thread(self.repo.get_workflow, self.workflow_file)
         except UnknownObjectException as e:
@@ -172,6 +171,7 @@ class GitHubRun:
             pprint.pformat(inputs),
         )
         success = await asyncio.to_thread(workflow.create_dispatch, branch_name, inputs=inputs)
+        trigger_time = datetime.datetime.now(datetime.timezone.utc)
 
         if success:
             wait_seconds = 5


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes in this pull request.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
