### PR TITLE
Remove automatic creation of active-leaderboards channels

### DIFF
--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -119,7 +119,6 @@ class ClusterBot(commands.Bot):
         forum_channel = None
         submission_channel = None
         general_channel = None
-        leaderboard_channel = None
         for channel in category.channels:
             if channel.name == "central" and isinstance(channel, discord.ForumChannel):
                 forum_channel = channel
@@ -127,8 +126,6 @@ class ClusterBot(commands.Bot):
                 submission_channel = channel
             elif channel.name == "general" and isinstance(channel, discord.TextChannel):
                 general_channel = channel
-            elif channel.name == "active-leaderboards" and isinstance(channel, discord.TextChannel):
-                leaderboard_channel = channel
 
         if not forum_channel:
             forum_channel = await category.create_forum(
@@ -140,18 +137,6 @@ class ClusterBot(commands.Bot):
                 name="general", reason="Created for leaderboard general"
             )
 
-        if not leaderboard_channel:
-            overwrites = {
-                guild.default_role: discord.PermissionOverwrite(
-                    read_messages=True, send_messages=False
-                ),
-                guild.me: discord.PermissionOverwrite(read_messages=True, send_messages=True),
-            }
-            leaderboard_channel = await category.create_text_channel(
-                name="active-leaderboards",
-                reason="Created for viewing leaderboards",
-                overwrites=overwrites,
-            )
 
         if not submission_channel:
             submission_channel = await category.create_text_channel(

--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -137,7 +137,6 @@ class ClusterBot(commands.Bot):
                 name="general", reason="Created for leaderboard general"
             )
 
-
         if not submission_channel:
             submission_channel = await category.create_text_channel(
                 name="submissions", reason="Created for leaderboard submissions"

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -9,7 +9,7 @@ from consts import (
     get_gpu_by_name,
 )
 from discord import app_commands
-from discord.ext import commands, tasks
+from discord.ext import commands
 from leaderboard_db import leaderboard_name_autocomplete
 from report import MultiProgressReporter
 from submission import SubmissionRequest, prepare_submission
@@ -376,10 +376,6 @@ class LeaderboardCog(commands.Cog):
         self.get_submission_by_id = bot.leaderboard_group.command(
             name="get-submission", description="Retrieve one of your past submissions"
         )(self.get_submission_by_id)
-
-        # Start updating leaderboard
-        self.leaderboard_update.start()
-
 
     # --------------------------------------------------------------------------
     # |                           HELPER FUNCTIONS                              |

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -380,45 +380,10 @@ class LeaderboardCog(commands.Cog):
         # Start updating leaderboard
         self.leaderboard_update.start()
 
-    # --------------------------------------------------------------------------
-    # |                           LOOPING FUNCTIONS                            |
-    # --------------------------------------------------------------------------
-    @tasks.loop(minutes=1)
-    async def leaderboard_update(self):
-        """Task that updates the leaderboard every minute."""
-        for guild in self.bot.guilds:
-            channel = await self.ensure_channel_exists(guild, "active-leaderboards")
-
-            # Get the pinned message or create a new one
-            pinned_messages = await channel.pins()
-            if pinned_messages:
-                message = pinned_messages[0]
-            else:
-                message = await channel.send("Loading leaderboard...")
-                await message.pin()
-
-            # Update the leaderboard message
-            embed, view = await self._get_leaderboard_helper()
-
-            if embed:
-                await message.edit(content="", embed=embed, view=view)
-            else:
-                await message.edit(content="There are currently no active leaderboards.")
-
-    @leaderboard_update.before_loop
-    async def before_leaderboard_update(self):
-        """Wait for the bot to be ready before starting the task."""
-        await self.bot.wait_until_ready()
 
     # --------------------------------------------------------------------------
     # |                           HELPER FUNCTIONS                              |
     # --------------------------------------------------------------------------
-    async def ensure_channel_exists(self, guild, channel_name):
-        """Ensure the leaderboard channel exists, and create it if not."""
-        channel = discord.utils.get(guild.text_channels, name=channel_name)
-        if not channel:
-            channel = await guild.create_text_channel(channel_name)
-        return channel
 
     async def _display_lb_submissions_helper(
         self,

--- a/src/discord-cluster-manager/report.py
+++ b/src/discord-cluster-manager/report.py
@@ -51,6 +51,7 @@ class Text:
     """
     Text represents markdown-formatted text to be added to the report.
     """
+
     text: str
 
 
@@ -64,6 +65,7 @@ class Log:
     message, it can be broken up automatically (and reasonably) into multiple
     smaller messages.
     """
+
     header: str
     content: str
 


### PR DESCRIPTION
## Description

Remove the code bloacks that automatically create "active-leaderboards" channels

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- ❌ (Don't have access to runners) Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
