### PR TITLE
Fix: make run_config respect timeout specifications

### DIFF
--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -549,6 +549,9 @@ def run_config(config: dict):
         "benchmarks": build_test_string(config.get("benchmarks", [])),
         "seed": config.get("seed", None),
         "ranking_by": config.get("ranking_by", "last"),
+        "ranked_timeout": config.get("ranked_timeout", Timeout.RANKED),
+        "benchmark_timeout": config.get("benchmark_timeout", Timeout.BENCHMARK),
+        "test_timeout": config.get("test_timeout", Timeout.TEST),
     }
     if config["lang"] == "py":
         runner = functools.partial(


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes in this pull request.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
