### PR TITLE
Feat: fix gh finding old runs

### DIFF
--- a/src/discord-cluster-manager/launchers/github.py
+++ b/src/discord-cluster-manager/launchers/github.py
@@ -62,7 +62,7 @@ class GitHubLauncher(Launcher):
             if gpu_vendor == "AMD":
                 inputs["runner"] = runner_name
 
-        async with self.trigger_limit:
+        async with self.trigger_limit:  # DO NOT REMOVE, PREVENTS A RACE CONDITION
             if not await run.trigger(inputs):
                 raise RuntimeError(
                     "Failed to trigger GitHub Action. Please check the configuration."
@@ -197,7 +197,9 @@ class GitHubRun:
                         logger.debug(
                             f"Checking run {run.id} created at {run.created_at.isoformat()}"
                         )
-                        if run.created_at.replace(tzinfo=datetime.timezone.utc) > trigger_time:
+                        if run.created_at.replace(
+                            tzinfo=datetime.timezone.utc
+                        ) > trigger_time - datetime.timedelta(seconds=2):
                             found_run = run
                             logger.info(f"Found matching workflow run: ID {found_run.id}")
                             break


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes in this pull request.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
