### PR TITLE
fix/update

### DIFF
--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -750,9 +750,12 @@ class AdminCog(commands.Cog):
                                 entry["name"], new_lb["deadline"], task.description
                             )
                         )
-                except discord.errors.NotFound:
+                except (discord.errors.NotFound, discord.HTTPException) as e:
                     logger.warning(
-                        "Could not find forum thread %s for lb %s", forum_id, entry["name"]
+                        "Could not find forum thread %s for lb %s",
+                        forum_id,
+                        entry["name"],
+                        exc_info=e,
                     )
                     pass
 

--- a/src/discord-cluster-manager/run_eval.py
+++ b/src/discord-cluster-manager/run_eval.py
@@ -549,10 +549,15 @@ def run_config(config: dict):
         "benchmarks": build_test_string(config.get("benchmarks", [])),
         "seed": config.get("seed", None),
         "ranking_by": config.get("ranking_by", "last"),
-        "ranked_timeout": config.get("ranked_timeout", Timeout.RANKED),
-        "benchmark_timeout": config.get("benchmark_timeout", Timeout.BENCHMARK),
-        "test_timeout": config.get("test_timeout", Timeout.TEST),
     }
+
+    if "ranked_timeout" in config:
+        common_args["ranked_timeout"] = config["ranked_timeout"]
+    if "benchmark_timeout" in config:
+        common_args["benchmark_timeout"] = config["benchmark_timeout"]
+    if "test_timeout" in config:
+        common_args["test_timeout"] = config["test_timeout"]
+
     if config["lang"] == "py":
         runner = functools.partial(
             run_pytorch_script,


### PR DESCRIPTION
- **Fix: revert timeouts back to default unless overriden**
- **Fix: another possible error**

## Description

Please provide a brief summary of the changes in this pull request.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
