### PR TITLE
Add help command linking to docs

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -377,6 +377,10 @@ class LeaderboardCog(commands.Cog):
             name="get-submission", description="Retrieve one of your past submissions"
         )(self.get_submission_by_id)
 
+        self.get_help = bot.leaderboard_group.command(
+            name="help", description="Get a summary of commands and a link to the documentation"
+        )(self.get_help)
+
         # Start updating leaderboard
         self.leaderboard_update.start()
 
@@ -765,3 +769,44 @@ class LeaderboardCog(commands.Cog):
             msg += "\n"
 
         await send_discord_message(interaction, msg, ephemeral=True, file=file)
+
+    # Help
+    @with_error_handling
+    async def get_help(
+        self,
+        interaction: discord.Interaction,
+    ):
+        help_message = """
+# Leaderboard Commands Help
+
+## Basic Commands
+- `/get-api-url` \
+- For popcorn-cli users, get the API URL
+- `/leaderboard list` \
+- View all active leaderboards
+- `/leaderboard help` \
+- Show this help message
+- `/leaderboard show <leaderboard_name>` \
+- View all submissions for a leaderboard
+- `/leaderboard show-personal <leaderboard_name>` \
+- View your submissions for a leaderboard
+
+## Submission Commands
+- `/leaderboard submit ranked <leaderboard_name> <script>` \
+- Submit a ranked run for a leaderboard
+- `/leaderboard submit test <leaderboard_name> <script>` \
+- Test your submission without affecting rankings
+- `/leaderboard get-submission <submission_id>` \
+- Retrieve one of your past submissions
+
+## Task Information
+- `/leaderboard task <leaderboard_name>` \
+- Get reference code for a leaderboard
+- `/leaderboard template <leaderboard_name> <language>` \
+- Get a starter template for a task
+
+## Documentation
+For more detailed information, visit our documentation:
+https://gpu-mode.github.io/discord-cluster-manager/docs/intro/
+"""
+        await send_discord_message(interaction, help_message, ephemeral=True)


### PR DESCRIPTION
## Description

Adds `/leaderboard help` which gives a summary of the commands and links to the documentation.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- ❌ (skipped) Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
