### PR TITLE
Skip GPU selection prompt if only 1 possible GPU

### DIFF
--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -487,6 +487,18 @@ class LeaderboardCog(commands.Cog):
                     return
 
                 gpus = db.get_leaderboard_gpu_types(leaderboard_name)
+
+                if len(gpus) == 1:
+                    submission = db.get_leaderboard_submissions(leaderboard_name, gpus[0], user_id)
+                    await self._display_lb_submissions_helper(
+                        submission,
+                        interaction,
+                        leaderboard_name,
+                        gpus[0],
+                        user_id,
+                    )
+                    return
+
                 for gpu in gpus:
                     submissions[gpu] = db.get_leaderboard_submissions(
                         leaderboard_name, gpu, user_id


### PR DESCRIPTION
## Description

Skip GPU selection prompt if only 1 possible GPU

Before:
(1 GPU available for leaderboard)
<img width="581" alt="Screenshot 2025-05-02 at 11 16 18 AM" src="https://github.com/user-attachments/assets/cfbd0fd5-4afe-4ab2-b432-5e009da239c1" />

After:
(1 GPU available for leaderboard)
<img width="581" alt="Screenshot 2025-05-02 at 10 48 04 AM" src="https://github.com/user-attachments/assets/95447409-f913-4fa4-9234-57e3d283a624" />

(multiple GPUs available for leaderboard)
<img width="525" alt="Screenshot 2025-05-02 at 11 20 55 AM" src="https://github.com/user-attachments/assets/cfdc0732-01a7-4697-9554-1cc601ecc971" />




## Checklist

Before submitting this PR, ensure the following steps have been completed:

- ❌ (skipped, don't have runners set up) Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
