### PR TITLE
Add index runs(runner, score)

### DIFF
--- a/src/discord-cluster-manager/migrations/20250506_01_38PkG-add-index-on-runs-runner-score.py
+++ b/src/discord-cluster-manager/migrations/20250506_01_38PkG-add-index-on-runs-runner-score.py
@@ -1,0 +1,14 @@
+"""
+add index on runs(runner, score)
+"""
+
+from yoyo import step
+
+__depends__ = {'20250412_02_NN9kK-user-info-cli-drop-old'}
+
+steps = [
+    step(
+        "CREATE INDEX IF NOT EXISTS runs_runner_score_idx ON leaderboard.runs(runner, score)",
+         "DROP INDEX IF EXISTS leaderboard.runs_runner_score_idx"
+        )
+]


### PR DESCRIPTION
## Description

This adds an index on the runs table to reduce the load time for the main page.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
