### PR TITLE
Fix Timeout Bug

### DIFF
--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -29,7 +29,7 @@ jobs:
       shell: bash
       run: |
         # Extract the payload content without printing it
-        sudo apt-get update && sudo apt-get install -y jq
+        apt-get update && apt-get install -y jq
         PAYLOAD=$(jq -r '.inputs.payload' $GITHUB_EVENT_PATH)
         
         # Apply mask to the extracted content

--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -29,6 +29,7 @@ jobs:
       shell: bash
       run: |
         # Extract the payload content without printing it
+        sudo apt-get update && sudo apt-get install -y jq
         PAYLOAD=$(jq -r '.inputs.payload' $GITHUB_EVENT_PATH)
         
         # Apply mask to the extracted content

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -145,6 +145,8 @@ CUDA_FLAGS = [
 ]
 MODAL_CUDA_INCLUDE_DIRS = ["/ThunderKittens/include"]
 
+DEFAULT_GITHUB_TIMEOUT_MINUTES = 10  # Default timeout for GitHub launcher in minutes
+
 NVIDIA_REQUIREMENTS = """
 numpy
 torch

--- a/src/discord-cluster-manager/consts.py
+++ b/src/discord-cluster-manager/consts.py
@@ -159,3 +159,6 @@ AMD_REQUIREMENTS = """
 --index-url https://download.pytorch.org/whl/rocm6.2.4
 torch
 """
+
+# A buffer for timeouts to account for github setup time
+TIMEOUT_BUFFER_MINUTES = 2

--- a/src/discord-cluster-manager/launchers/github.py
+++ b/src/discord-cluster-manager/launchers/github.py
@@ -13,6 +13,7 @@ from consts import (
     DEFAULT_GITHUB_TIMEOUT_MINUTES,
     GPU,
     NVIDIA_REQUIREMENTS,
+    TIMEOUT_BUFFER_MINUTES,
     GitHubGPU,
     SubmissionMode,
 )
@@ -88,7 +89,7 @@ class GitHubLauncher(Launcher):
         await status.push("⏳ Waiting for workflow to start...")
         logger.info("Waiting for workflow to start...")
 
-        timeout = get_timeout(config)
+        timeout = get_timeout(config) + TIMEOUT_BUFFER_MINUTES
         logger.info(f"Waiting for workflow to complete... (timeout: {timeout} minutes)")
         await run.wait_for_completion(
             lambda x: self.wait_callback(x, status),

--- a/src/discord-cluster-manager/launchers/github.py
+++ b/src/discord-cluster-manager/launchers/github.py
@@ -25,128 +25,234 @@ from .launcher import Launcher
 
 logger = setup_logging()
 
+def get_timeout(config: dict) -> int:
+    mode = config.get("mode")
+    sec_map = {
+        SubmissionMode.TEST.value: config.get("test_timeout"),
+        SubmissionMode.BENCHMARK.value: config.get("benchmark_timeout"),
+        SubmissionMode.LEADERBOARD.value: config.get("ranked_timeout"),
+    }
+    seconds = sec_map.get(mode) or DEFAULT_GITHUB_TIMEOUT_MINUTES * 60
+    return math.ceil(seconds / 60)
+
 class GitHubLauncher(Launcher):
-    class GitHubRun:
-        def __init__(self, repo: str, token: str, workflow_file: str):
-            gh = Github(token)
-            self.repo = gh.get_repo(repo)
-            self.token = token
-            self.workflow_file = workflow_file
-            self.run: Optional[WorkflowRun.WorkflowRun] = None
-            self.start_time = None
+    def __init__(self, repo: str, token: str):
+        super().__init__(name="GitHub", gpus=GitHubGPU)
+        self.repo = repo
+        self.token = token
+        self.trigger_limit = asyncio.Semaphore(1)
 
-        @property
-        def run_id(self):
-            if self.run is None:
-                return None
-            return self.run.id
+    async def run_submission(
+        self, config: dict, gpu_type: GPU, status: RunProgressReporter
+    ) -> FullResult:
+        gpu_vendor = None
+        if gpu_type.value in ["MI300", "MI250"]:
+            selected_workflow = "amd_workflow.yml"
+            runner_name = {"MI300": "amdgpu-mi300-x86-64", "MI250": "amdgpu-mi250-x86-64"}[
+                gpu_type.value
+            ]
+            gpu_vendor = "AMD"
+            requirements = AMD_REQUIREMENTS
+        elif gpu_type.value == "NVIDIA":
+            selected_workflow = "nvidia_workflow.yml"
+            gpu_vendor = "NVIDIA"
+            requirements = NVIDIA_REQUIREMENTS
+        else:
+            raise ValueError(f"Invalid GPU type: {gpu_type.value}")
 
-        @property
-        def html_url(self):
-            if self.run is None:
-                return None
-            return self.run.html_url
+        lang = config["lang"]
+        if lang == "cu" and gpu_vendor == "AMD":
+            # TODO implement HIP
+            raise NotImplementedError("Cannot use CUDA runs with AMD GPUs")
 
-        @property
-        def status(self):
-            if self.run is None:
-                return None
-            return self.run.status
+        lang_name = {"py": "Python", "cu": "CUDA"}[lang]
 
-        @property
-        def elapsed_time(self):
-            if self.start_time is None:
-                return None
-            return datetime.datetime.now(datetime.timezone.utc) - self.start_time
+        logger.info(f"Attempting to trigger GitHub action for {lang_name} on {selected_workflow}")
+        run = GitHubRun(self.repo, self.token, selected_workflow)
+        logger.info(f"Successfully created GitHub run: {run.run_id}")
 
-        async def trigger(self, inputs: dict) -> bool:
-            """
-            Trigger this run with the provided inputs.
-            Sets `self.run` to the new WorkflowRun on success.
+        payload = json.dumps(config)
 
-            Returns: Whether the run was successfully triggered,
-            """
-            trigger_time = datetime.datetime.now(datetime.timezone.utc)
-            try:
-                workflow = await asyncio.to_thread(self.repo.get_workflow, self.workflow_file)
-            except UnknownObjectException as e:
-                logger.error(f"Could not find workflow {self.workflow_file}", exc_info=e)
-                raise ValueError(f"Could not find workflow {self.workflow_file}") from e
+        inputs = {"payload": payload}
+        if lang == "py":
+            inputs["requirements"] = requirements
+            if gpu_vendor == "AMD":
+                inputs["runner"] = runner_name
 
-            branch_name = get_github_branch_name()
-            logger.debug(
-                "Dispatching workflow %s on branch %s with inputs %s",
-                self.workflow_file,
-                branch_name,
-                pprint.pformat(inputs),
+        async with self.trigger_limit:  # DO NOT REMOVE, PREVENTS A RACE CONDITION
+            if not await run.trigger(inputs):
+                raise RuntimeError(
+                    "Failed to trigger GitHub Action. Please check the configuration."
+                )
+
+        await status.push("⏳ Waiting for workflow to start...")
+        logger.info("Waiting for workflow to start...")
+
+        timeout = get_timeout(config)
+        logger.info(f"Waiting for workflow to complete... (timeout: {timeout} minutes)")
+        await run.wait_for_completion(
+            lambda x: self.wait_callback(x, status),
+            timeout_minutes=timeout
             )
-            success = await asyncio.to_thread(workflow.create_dispatch, branch_name, inputs=inputs)
+        await status.update(f"Workflow [{run.run_id}]({run.html_url}) completed")
+        logger.info(f"Workflow [{run.run_id}]({run.html_url}) completed")
+        await status.push("Downloading artifacts...")
+        logger.info("Downloading artifacts...")
 
-            if success:
-                wait_seconds = 5
-                logger.info(
-                    f"Workflow dispatch successful. Waiting {wait_seconds}s for the run to "
-                    "appear..."
-                )
-                await asyncio.sleep(wait_seconds)
-                recent_runs_paginated = await asyncio.to_thread(
-                    workflow.get_runs, event="workflow_dispatch"
-                )
+        artifacts = await run.download_artifacts()
+        if "run-result" not in artifacts:
+            logger.error("Could not find `run-result` among artifacts: %s", artifacts.keys())
+            await status.push("Downloading artifacts...  failed")
+            return FullResult(
+                success=False, error="Could not download artifacts", runs={}, system=SystemInfo()
+            )
 
-                logger.info(
-                    f"Checking recent workflow_dispatch runs after {trigger_time.isoformat()}..."
-                )
-                found_run = None
-                runs_checked = 0
-                try:
-                    run_iterator = recent_runs_paginated.__iter__()
-                    while runs_checked < 50:
-                        try:
-                            run = next(run_iterator)
-                            runs_checked += 1
-                            logger.debug(
-                                f"Checking run {run.id} created at {run.created_at.isoformat()}"
-                            )
-                            if run.created_at.replace(
-                                tzinfo=datetime.timezone.utc
-                            ) > trigger_time - datetime.timedelta(seconds=2):
-                                found_run = run
-                                logger.info(f"Found matching workflow run: ID {found_run.id}")
-                                break
-                            else:
-                                logger.info(
-                                    f"Run {run.id} is older than trigger time, "
-                                    "stopping check."
-                                )
-                                break
-                        except StopIteration:
-                            logger.debug("Reached end of recent runs list.")
-                            break
-                except Exception as e:
-                    logger.error(f"Error iterating through recent runs: {e}", exc_info=True)
-                    return False
+        logs = artifacts["run-result"]["result.json"].decode("utf-8")
 
-                if found_run:
-                    self.run = found_run
-                    return True
-                else:
-                    logger.warning(
-                        f"Could not find a workflow run created after {trigger_time.isoformat()}."
-                    )
-                    return False
+        await status.update("Downloading artifacts... done")
+        logger.info("Downloading artifacts... done")
+
+        data = json.loads(logs)
+        runs = {}
+        # convert json back to EvalResult structures, which requires
+        # special handling for datetime and our dataclasses.
+        for k, v in data["runs"].items():
+            if "compilation" in v and v["compilation"] is not None:
+                comp = CompileResult(**v["compilation"])
             else:
-                logger.error(
-                    f"Failed to dispatch workflow {self.workflow_file} on branch {branch_name}."
-                )
+                comp = None
+            run = RunResult(**v["run"])
+            res = EvalResult(
+                start=datetime.datetime.fromisoformat(v["start"]),
+                end=datetime.datetime.fromisoformat(v["end"]),
+                compilation=comp,
+                run=run,
+            )
+            runs[k] = res
+
+        system = SystemInfo(**data.get("system", {}))
+        return FullResult(success=True, error="", runs=runs, system=system)
+
+    async def wait_callback(self, run: "GitHubRun", status: RunProgressReporter):
+        await status.update(
+            f"⏳ Workflow [{run.run_id}]({run.html_url}): {run.status} "
+            f"({run.elapsed_time.total_seconds():.1f}s)"
+        )
+
+
+class GitHubRun:
+    def __init__(self, repo: str, token: str, workflow_file: str):
+        gh = Github(token)
+        self.repo = gh.get_repo(repo)
+        self.token = token
+        self.workflow_file = workflow_file
+        self.run: Optional[WorkflowRun.WorkflowRun] = None
+        self.start_time = None
+
+    @property
+    def run_id(self):
+        if self.run is None:
+            return None
+        return self.run.id
+
+    @property
+    def html_url(self):
+        if self.run is None:
+            return None
+        return self.run.html_url
+
+    @property
+    def status(self):
+        if self.run is None:
+            return None
+        return self.run.status
+
+    @property
+    def elapsed_time(self):
+        if self.start_time is None:
+            return None
+        return datetime.datetime.now(datetime.timezone.utc) - self.start_time
+
+    async def trigger(self, inputs: dict) -> bool:
+        """
+        Trigger this run with the provided inputs.
+        Sets `self.run` to the new WorkflowRun on success.
+
+        Returns: Whether the run was successfully triggered,
+        """
+        trigger_time = datetime.datetime.now(datetime.timezone.utc)
+        try:
+            workflow = await asyncio.to_thread(self.repo.get_workflow, self.workflow_file)
+        except UnknownObjectException as e:
+            logger.error(f"Could not find workflow {self.workflow_file}", exc_info=e)
+            raise ValueError(f"Could not find workflow {self.workflow_file}") from e
+
+        branch_name = get_github_branch_name()
+        logger.debug(
+            "Dispatching workflow %s on branch %s with inputs %s",
+            self.workflow_file,
+            branch_name,
+            pprint.pformat(inputs),
+        )
+        success = await asyncio.to_thread(workflow.create_dispatch, branch_name, inputs=inputs)
+
+        if success:
+            wait_seconds = 5
+            logger.info(
+                f"Workflow dispatch successful. Waiting {wait_seconds}s for the run to appear..."
+            )
+            await asyncio.sleep(wait_seconds)
+            recent_runs_paginated = await asyncio.to_thread(
+                workflow.get_runs, event="workflow_dispatch"
+            )
+
+            logger.info(
+                f"Checking recent workflow_dispatch runs after {trigger_time.isoformat()}..."
+            )
+            found_run = None
+            runs_checked = 0
+            try:
+                run_iterator = recent_runs_paginated.__iter__()
+                while runs_checked < 50:
+                    try:
+                        run = next(run_iterator)
+                        runs_checked += 1
+                        logger.debug(
+                            f"Checking run {run.id} created at {run.created_at.isoformat()}"
+                        )
+                        if run.created_at.replace(
+                            tzinfo=datetime.timezone.utc
+                        ) > trigger_time - datetime.timedelta(seconds=2):
+                            found_run = run
+                            logger.info(f"Found matching workflow run: ID {found_run.id}")
+                            break
+                        else:
+                            logger.info(f"Run {run.id} is older than trigger time, stopping check.")
+                            break
+                    except StopIteration:
+                        logger.debug("Reached end of recent runs list.")
+                        break
+            except Exception as e:
+                logger.error(f"Error iterating through recent runs: {e}", exc_info=True)
                 return False
 
+            if found_run:
+                self.run = found_run
+                return True
+            else:
+                logger.warning(
+                    f"Could not find a workflow run created after {trigger_time.isoformat()}."
+                )
+                return False
+        else:
+            logger.error(
+                f"Failed to dispatch workflow {self.workflow_file} on branch {branch_name}."
+            )
+            return False
+
     async def wait_for_completion(
-        self,
-        callback: Callable[["GitHubRun"],
-        Awaitable[None]],
-        timeout_minutes: int = DEFAULT_GITHUB_TIMEOUT_MINUTES
+        self, callback: Callable[["GitHubRun"], Awaitable[None]], timeout_minutes: int = 10
     ):
-        logger.info(f"the timeout is {timeout_minutes}")
         if self.run is None:
             raise ValueError("Run needs to be triggered before a status check!")
 
@@ -220,125 +326,5 @@ class GitHubLauncher(Launcher):
                     f"Status code: {response.status_code}"
                 )
 
-        logger.info("Download artifacts for run %s: %s",
-        self.run_id,
-        list(extracted.keys()))
+        logger.info("Download artifacts for run %s: %s", self.run_id, list(extracted.keys()))
         return extracted
-
-
-    def __init__(self, repo: str, token: str):
-        super().__init__(name="GitHub", gpus=GitHubGPU)
-        self.repo = repo
-        self.token = token
-        self.trigger_limit = asyncio.Semaphore(1)
-
-    async def run_submission(
-        self, config: dict, gpu_type: GPU, status: RunProgressReporter
-    ) -> FullResult:
-        selected_workflow, runner_name, requirements = self._select_workflow_params(gpu_type)
-        if gpu_type.value in ["MI300", "MI250"]:
-            gpu_vendor = "AMD"
-        elif gpu_type.value == "NVIDIA":
-            gpu_vendor = "NVIDIA"
-        else:
-            raise ValueError(f"Invalid GPU type: {gpu_type.value}")
-
-        lang = config["lang"]
-        if lang == "cu" and gpu_vendor == "AMD":
-            # TODO implement HIP
-            raise NotImplementedError("Cannot use CUDA runs with AMD GPUs")
-
-        lang_name = {"py": "Python", "cu": "CUDA"}[lang]
-
-        logger.info(f"Attempting to trigger GitHub action for {lang_name} on {selected_workflow}")
-        run = self.GitHubRun(self.repo, self.token, selected_workflow)
-        logger.info(f"Successfully created GitHub run: {run.run_id}")
-
-        payload = json.dumps(config)
-
-        inputs = {"payload": payload}
-        if lang == "py":
-            inputs["requirements"] = requirements
-            if gpu_vendor == "AMD":
-                inputs["runner"] = runner_name
-
-        async with self.trigger_limit:  # DO NOT REMOVE, PREVENTS A RACE CONDITION
-            if not await run.trigger(inputs):
-                raise RuntimeError(
-                    "Failed to trigger GitHub Action. Please check the configuration."
-                )
-
-        await status.push("⏳ Waiting for workflow to start...")
-        logger.info("Waiting for workflow to start...")
-
-        timeout_minutes = self._compute_timeout_minutes(config)
-        await run.wait_for_completion(
-            lambda x: self.wait_callback(x, status), timeout_minutes=timeout_minutes
-        )
-        await status.update(f"Workflow [{run.run_id}]({run.html_url}) completed")
-        logger.info(f"Workflow [{run.run_id}]({run.html_url}) completed")
-        await status.push("⏳ Downloading artifacts...")
-        return await self._handle_artifacts(run, status)
-
-    async def wait_callback(self, run: "GitHubRun", status: RunProgressReporter):
-        await status.update(
-            f"⏳ Workflow [{run.run_id}]({run.html_url}): {run.status} "
-            f"({run.elapsed_time.total_seconds():.1f}s)"
-        )
-
-    def _select_workflow_params(self, gpu_type: GPU) -> tuple[str, Optional[str], str]:
-        """
-        Returns workflow file, runner name (if any), and requirements for given GPU.
-        """
-        if gpu_type.value in ["MI300", "MI250"]:
-            runner = {
-                "MI300": "amdgpu-mi300-x86-64",
-                "MI250": "amdgpu-mi250-x86-64",
-            }[gpu_type.value]
-            return "amd_workflow.yml", runner, AMD_REQUIREMENTS
-        if gpu_type.value == "NVIDIA":
-            return "nvidia_workflow.yml", None, NVIDIA_REQUIREMENTS
-        raise ValueError(f"Invalid GPU type: {gpu_type.value}")
-
-    def _compute_timeout_minutes(self, config: dict) -> int:
-        """
-        Compute timeout in minutes based on submission mode and config timeouts.
-        """
-        mode = config.get("mode")
-        sec_map = {
-            SubmissionMode.TEST.value: config.get("test_timeout"),
-            SubmissionMode.BENCHMARK.value: config.get("benchmark_timeout"),
-            SubmissionMode.LEADERBOARD.value: config.get("ranked_timeout"),
-        }
-        seconds = sec_map.get(mode) or DEFAULT_GITHUB_TIMEOUT_MINUTES * 60
-        return math.ceil(seconds / 60)
-
-    async def _handle_artifacts(
-        self,
-        run: GitHubRun,
-        status: RunProgressReporter
-    ) -> FullResult:
-        logger.info("Downloading artifacts...")
-        artifacts = await run.download_artifacts()
-        if "run-result" not in artifacts:
-            logger.error("Could not find `run-result` among artifacts: %s", artifacts.keys())
-            await status.push("Downloading artifacts...  failed")
-            return FullResult(success=False,
-            error="Could not download artifacts", runs={},
-            system=SystemInfo())
-        logs = artifacts["run-result"]["result.json"].decode("utf-8")
-        await status.update("✅ Downloading artifacts... done")
-        logger.info("Downloading artifacts... done")
-        data = json.loads(logs)
-        runs: dict[str, EvalResult] = {}
-        for key, v in data.get("runs", {}).items():
-            comp = CompileResult(**v["compilation"]) if v.get("compilation") else None
-            res_run = RunResult(**v["run"])
-            runs[key] = EvalResult(
-                start=datetime.datetime.fromisoformat(v["start"]),
-                end=datetime.datetime.fromisoformat(v["end"]),
-                compilation=comp,
-                run=res_run,
-            )
-        system = SystemInfo(**data.get("system", {}))
-        return FullResult(success=True, error="", runs=runs, system=system)

--- a/src/discord-cluster-manager/launchers/github.py
+++ b/src/discord-cluster-manager/launchers/github.py
@@ -25,116 +25,120 @@ from .launcher import Launcher
 
 logger = setup_logging()
 
+class GitHubLauncher(Launcher):
+    class GitHubRun:
+        def __init__(self, repo: str, token: str, workflow_file: str):
+            gh = Github(token)
+            self.repo = gh.get_repo(repo)
+            self.token = token
+            self.workflow_file = workflow_file
+            self.run: Optional[WorkflowRun.WorkflowRun] = None
+            self.start_time = None
 
-class GitHubRun:
-    def __init__(self, repo: str, token: str, workflow_file: str):
-        gh = Github(token)
-        self.repo = gh.get_repo(repo)
-        self.token = token
-        self.workflow_file = workflow_file
-        self.run: Optional[WorkflowRun.WorkflowRun] = None
-        self.start_time = None
+        @property
+        def run_id(self):
+            if self.run is None:
+                return None
+            return self.run.id
 
-    @property
-    def run_id(self):
-        if self.run is None:
-            return None
-        return self.run.id
+        @property
+        def html_url(self):
+            if self.run is None:
+                return None
+            return self.run.html_url
 
-    @property
-    def html_url(self):
-        if self.run is None:
-            return None
-        return self.run.html_url
+        @property
+        def status(self):
+            if self.run is None:
+                return None
+            return self.run.status
 
-    @property
-    def status(self):
-        if self.run is None:
-            return None
-        return self.run.status
+        @property
+        def elapsed_time(self):
+            if self.start_time is None:
+                return None
+            return datetime.datetime.now(datetime.timezone.utc) - self.start_time
 
-    @property
-    def elapsed_time(self):
-        if self.start_time is None:
-            return None
-        return datetime.datetime.now(datetime.timezone.utc) - self.start_time
+        async def trigger(self, inputs: dict) -> bool:
+            """
+            Trigger this run with the provided inputs.
+            Sets `self.run` to the new WorkflowRun on success.
 
-    async def trigger(self, inputs: dict) -> bool:
-        """
-        Trigger this run with the provided inputs.
-        Sets `self.run` to the new WorkflowRun on success.
-
-        Returns: Whether the run was successfully triggered,
-        """
-        trigger_time = datetime.datetime.now(datetime.timezone.utc)
-        try:
-            workflow = await asyncio.to_thread(self.repo.get_workflow, self.workflow_file)
-        except UnknownObjectException as e:
-            logger.error(f"Could not find workflow {self.workflow_file}", exc_info=e)
-            raise ValueError(f"Could not find workflow {self.workflow_file}") from e
-
-        branch_name = get_github_branch_name()
-        logger.debug(
-            "Dispatching workflow %s on branch %s with inputs %s",
-            self.workflow_file,
-            branch_name,
-            pprint.pformat(inputs),
-        )
-        success = await asyncio.to_thread(workflow.create_dispatch, branch_name, inputs=inputs)
-
-        if success:
-            wait_seconds = 5
-            logger.info(
-                f"Workflow dispatch successful. Waiting {wait_seconds}s for the run to appear..."
-            )
-            await asyncio.sleep(wait_seconds)
-            recent_runs_paginated = await asyncio.to_thread(
-                workflow.get_runs, event="workflow_dispatch"
-            )
-
-            logger.info(
-                f"Checking recent workflow_dispatch runs after {trigger_time.isoformat()}..."
-            )
-            found_run = None
-            runs_checked = 0
+            Returns: Whether the run was successfully triggered,
+            """
+            trigger_time = datetime.datetime.now(datetime.timezone.utc)
             try:
-                run_iterator = recent_runs_paginated.__iter__()
-                while runs_checked < 50:
-                    try:
-                        run = next(run_iterator)
-                        runs_checked += 1
-                        logger.debug(
-                            f"Checking run {run.id} created at {run.created_at.isoformat()}"
-                        )
-                        if run.created_at.replace(
-                            tzinfo=datetime.timezone.utc
-                        ) > trigger_time - datetime.timedelta(seconds=2):
-                            found_run = run
-                            logger.info(f"Found matching workflow run: ID {found_run.id}")
-                            break
-                        else:
-                            logger.info(f"Run {run.id} is older than trigger time, stopping check.")
-                            break
-                    except StopIteration:
-                        logger.debug("Reached end of recent runs list.")
-                        break
-            except Exception as e:
-                logger.error(f"Error iterating through recent runs: {e}", exc_info=True)
-                return False
+                workflow = await asyncio.to_thread(self.repo.get_workflow, self.workflow_file)
+            except UnknownObjectException as e:
+                logger.error(f"Could not find workflow {self.workflow_file}", exc_info=e)
+                raise ValueError(f"Could not find workflow {self.workflow_file}") from e
 
-            if found_run:
-                self.run = found_run
-                return True
+            branch_name = get_github_branch_name()
+            logger.debug(
+                "Dispatching workflow %s on branch %s with inputs %s",
+                self.workflow_file,
+                branch_name,
+                pprint.pformat(inputs),
+            )
+            success = await asyncio.to_thread(workflow.create_dispatch, branch_name, inputs=inputs)
+
+            if success:
+                wait_seconds = 5
+                logger.info(
+                    f"Workflow dispatch successful. Waiting {wait_seconds}s for the run to "
+                    "appear..."
+                )
+                await asyncio.sleep(wait_seconds)
+                recent_runs_paginated = await asyncio.to_thread(
+                    workflow.get_runs, event="workflow_dispatch"
+                )
+
+                logger.info(
+                    f"Checking recent workflow_dispatch runs after {trigger_time.isoformat()}..."
+                )
+                found_run = None
+                runs_checked = 0
+                try:
+                    run_iterator = recent_runs_paginated.__iter__()
+                    while runs_checked < 50:
+                        try:
+                            run = next(run_iterator)
+                            runs_checked += 1
+                            logger.debug(
+                                f"Checking run {run.id} created at {run.created_at.isoformat()}"
+                            )
+                            if run.created_at.replace(
+                                tzinfo=datetime.timezone.utc
+                            ) > trigger_time - datetime.timedelta(seconds=2):
+                                found_run = run
+                                logger.info(f"Found matching workflow run: ID {found_run.id}")
+                                break
+                            else:
+                                logger.info(
+                                    f"Run {run.id} is older than trigger time, "
+                                    "stopping check."
+                                )
+                                break
+                        except StopIteration:
+                            logger.debug("Reached end of recent runs list.")
+                            break
+                except Exception as e:
+                    logger.error(f"Error iterating through recent runs: {e}", exc_info=True)
+                    return False
+
+                if found_run:
+                    self.run = found_run
+                    return True
+                else:
+                    logger.warning(
+                        f"Could not find a workflow run created after {trigger_time.isoformat()}."
+                    )
+                    return False
             else:
-                logger.warning(
-                    f"Could not find a workflow run created after {trigger_time.isoformat()}."
+                logger.error(
+                    f"Failed to dispatch workflow {self.workflow_file} on branch {branch_name}."
                 )
                 return False
-        else:
-            logger.error(
-                f"Failed to dispatch workflow {self.workflow_file} on branch {branch_name}."
-            )
-            return False
 
     async def wait_for_completion(
         self,
@@ -221,7 +225,7 @@ class GitHubRun:
         list(extracted.keys()))
         return extracted
 
-class GitHubLauncher(Launcher):
+
     def __init__(self, repo: str, token: str):
         super().__init__(name="GitHub", gpus=GitHubGPU)
         self.repo = repo
@@ -247,7 +251,7 @@ class GitHubLauncher(Launcher):
         lang_name = {"py": "Python", "cu": "CUDA"}[lang]
 
         logger.info(f"Attempting to trigger GitHub action for {lang_name} on {selected_workflow}")
-        run = GitHubRun(self.repo, self.token, selected_workflow)
+        run = self.GitHubRun(self.repo, self.token, selected_workflow)
         logger.info(f"Successfully created GitHub run: {run.run_id}")
 
         payload = json.dumps(config)


### PR DESCRIPTION
## Description

This pr makes it such that we actually use the specified timeouts from github when running a submission. This logic was missing before. There's also a bunch of refactoring changes to make the linter happy.

Testing:
There is now a snippet in the logs that looks like 
```
2025-05-14 17:26:57 - utils - INFO - Waiting for workflow to complete... (timeout: 3 minutes)
2025-05-14 17:26:57 - utils - INFO - Workflow dispatch successful. Waiting 5s for the run to appear..
```
which indicates that we are passing a non default value. The associated workflow is https://github.com/gpu-mode/discord-cluster-manager/actions/runs/15033809006 (I believe the failure is noisy)