### PR TITLE
[ez] install jq in nvidia workflow

### DIFF
--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -34,6 +34,10 @@ jobs:
     - name: Create input files
       shell: bash
       run: |
+
+        # install jq
+        apt update && apt install -y jq
+
         # Extract the payload content without printing it
         apt-get update && apt-get install -y jq
         PAYLOAD=$(jq -r '.inputs.payload' $GITHUB_EVENT_PATH)


### PR DESCRIPTION
jq is not in the docker image during local development so this pr installs it explictly