### PR TITLE
Disentangling discord

### DIFF
--- a/src/discord-cluster-manager/api/main.py
+++ b/src/discord-cluster-manager/api/main.py
@@ -10,8 +10,8 @@ from typing import Annotated, Optional
 from consts import SubmissionMode
 from fastapi import Depends, FastAPI, Header, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
+from leaderboard_db import LeaderboardRankedEntry
 from submission import SubmissionRequest
-from utils import LeaderboardRankedEntry
 
 from .utils import _handle_discord_oauth, _handle_github_oauth, _run_submission
 

--- a/src/discord-cluster-manager/bot.py
+++ b/src/discord-cluster-manager/bot.py
@@ -15,6 +15,8 @@ from cogs.verify_run_cog import VerifyRunCog
 from discord import app_commands
 from discord.ext import commands
 from env import (
+    DATABASE_URL,
+    DISABLE_SSL,
     DISCORD_CLUSTER_STAGING_ID,
     DISCORD_DEBUG_CLUSTER_STAGING_ID,
     DISCORD_DEBUG_TOKEN,
@@ -62,6 +64,8 @@ class ClusterBot(commands.Bot):
             POSTGRES_USER,
             POSTGRES_PASSWORD,
             POSTGRES_PORT,
+            url=DATABASE_URL,
+            ssl_mode="require" if not DISABLE_SSL else "disable",
         )
 
         try:

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -13,15 +13,13 @@ import yaml
 from consts import GitHubGPU, ModalGPU
 from discord import app_commands
 from discord.ext import commands, tasks
+from discord_utils import leaderboard_name_autocomplete, send_discord_message, with_error_handling
 from leaderboard_db import LeaderboardItem, SubmissionItem
 from task import LeaderboardTask, make_task
 from ui.misc import ConfirmationView, DeleteConfirmationModal, GPUSelectionView
 from utils import (
     KernelBotError,
-    leaderboard_name_autocomplete,
-    send_discord_message,
     setup_logging,
-    with_error_handling,
 )
 
 if TYPE_CHECKING:

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -13,13 +13,13 @@ import yaml
 from consts import GitHubGPU, ModalGPU
 from discord import app_commands
 from discord.ext import commands, tasks
-from leaderboard_db import leaderboard_name_autocomplete
 from task import LeaderboardTask, make_task
 from ui.misc import ConfirmationView, DeleteConfirmationModal, GPUSelectionView
 from utils import (
     KernelBotError,
     LeaderboardItem,
     SubmissionItem,
+    leaderboard_name_autocomplete,
     send_discord_message,
     setup_logging,
     with_error_handling,

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -13,12 +13,11 @@ import yaml
 from consts import GitHubGPU, ModalGPU
 from discord import app_commands
 from discord.ext import commands, tasks
+from leaderboard_db import LeaderboardItem, SubmissionItem
 from task import LeaderboardTask, make_task
 from ui.misc import ConfirmationView, DeleteConfirmationModal, GPUSelectionView
 from utils import (
     KernelBotError,
-    LeaderboardItem,
-    SubmissionItem,
     leaderboard_name_autocomplete,
     send_discord_message,
     setup_logging,

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -10,7 +10,6 @@ from consts import (
 )
 from discord import app_commands
 from discord.ext import commands
-from leaderboard_db import leaderboard_name_autocomplete
 from report import MultiProgressReporter
 from submission import SubmissionRequest, prepare_submission
 from ui.misc import GPUSelectionView
@@ -22,6 +21,7 @@ from utils import (
     SubmissionItem,
     format_time,
     get_user_from_id,
+    leaderboard_name_autocomplete,
     send_discord_message,
     setup_logging,
     with_error_handling,

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -10,6 +10,12 @@ from consts import (
 )
 from discord import app_commands
 from discord.ext import commands
+from discord_utils import (
+    get_user_from_id,
+    leaderboard_name_autocomplete,
+    send_discord_message,
+    with_error_handling,
+)
 from leaderboard_db import (
     LeaderboardItem,
     LeaderboardRankedEntry,
@@ -22,11 +28,7 @@ from ui.misc import GPUSelectionView
 from ui.table import create_table
 from utils import (
     format_time,
-    get_user_from_id,
-    leaderboard_name_autocomplete,
-    send_discord_message,
     setup_logging,
-    with_error_handling,
 )
 
 if TYPE_CHECKING:

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -10,6 +10,7 @@ from consts import (
 )
 from discord import app_commands
 from discord.ext import commands
+from discord_reporter import MultiProgressReporter
 from discord_utils import (
     get_user_from_id,
     leaderboard_name_autocomplete,
@@ -22,7 +23,6 @@ from leaderboard_db import (
     RunItem,
     SubmissionItem,
 )
-from report import MultiProgressReporter
 from submission import SubmissionRequest, prepare_submission
 from ui.misc import GPUSelectionView
 from ui.table import create_table

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -10,15 +10,17 @@ from consts import (
 )
 from discord import app_commands
 from discord.ext import commands
+from leaderboard_db import (
+    LeaderboardItem,
+    LeaderboardRankedEntry,
+    RunItem,
+    SubmissionItem,
+)
 from report import MultiProgressReporter
 from submission import SubmissionRequest, prepare_submission
 from ui.misc import GPUSelectionView
 from ui.table import create_table
 from utils import (
-    LeaderboardItem,
-    LeaderboardRankedEntry,
-    RunItem,
-    SubmissionItem,
     format_time,
     get_user_from_id,
     leaderboard_name_autocomplete,

--- a/src/discord-cluster-manager/cogs/misc_cog.py
+++ b/src/discord-cluster-manager/cogs/misc_cog.py
@@ -5,8 +5,9 @@ import discord
 import psycopg2
 from discord import app_commands
 from discord.ext import commands
+from discord_utils import send_discord_message
 from env import DATABASE_URL, DISABLE_SSL
-from utils import send_discord_message, setup_logging
+from utils import setup_logging
 
 if TYPE_CHECKING:
     from ..bot import ClusterBot

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -11,9 +11,9 @@ import discord
 from consts import GPU, GPU_TO_SM, RankCriterion, SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.ext import commands
+from discord_reporter import MultiProgressReporter
 from discord_utils import send_discord_message, with_error_handling
 from report import (
-    MultiProgressReporter,
     RunProgressReporter,
     generate_report,
     make_short_report,

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -18,10 +18,9 @@ from report import (
     make_short_report,
 )
 from run_eval import FullResult
-from task import LeaderboardTask
+from task import LeaderboardTask, build_task_config
 from utils import (
     KernelBotError,
-    build_task_config,
     send_discord_message,
     setup_logging,
     with_error_handling,

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -11,6 +11,7 @@ import discord
 from consts import GPU, GPU_TO_SM, RankCriterion, SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.ext import commands
+from discord_utils import send_discord_message, with_error_handling
 from report import (
     MultiProgressReporter,
     RunProgressReporter,
@@ -21,9 +22,7 @@ from run_eval import FullResult
 from task import LeaderboardTask, build_task_config
 from utils import (
     KernelBotError,
-    send_discord_message,
     setup_logging,
-    with_error_handling,
 )
 
 logger = setup_logging()

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -14,10 +14,11 @@ from consts import GPU, SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.app_commands import Choice
 from discord.ext import commands
+from discord_utils import send_discord_message, with_error_handling
 from leaderboard_db import RunItem, SubmissionItem
 from report import MultiProgressReporter
 from task import make_task
-from utils import send_discord_message, setup_logging, with_error_handling
+from utils import setup_logging
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -14,9 +14,9 @@ from consts import GPU, SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.app_commands import Choice
 from discord.ext import commands
+from discord_reporter import MultiProgressReporter
 from discord_utils import send_discord_message, with_error_handling
 from leaderboard_db import RunItem, SubmissionItem
-from report import MultiProgressReporter
 from task import make_task
 from utils import setup_logging
 

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -14,9 +14,10 @@ from consts import GPU, SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.app_commands import Choice
 from discord.ext import commands
+from leaderboard_db import RunItem, SubmissionItem
 from report import MultiProgressReporter
 from task import make_task
-from utils import RunItem, SubmissionItem, send_discord_message, setup_logging, with_error_handling
+from utils import send_discord_message, setup_logging, with_error_handling
 
 logger = setup_logging()
 

--- a/src/discord-cluster-manager/discord_reporter.py
+++ b/src/discord-cluster-manager/discord_reporter.py
@@ -1,0 +1,68 @@
+import discord
+from discord_utils import _send_split_log
+from report import Log, RunProgressReporter, RunResultReport, Text
+
+
+class MultiProgressReporter:
+    def __init__(self, interaction: discord.Interaction, header: str):
+        self.header = header
+        self.runs = []
+        self.interaction = interaction
+
+    async def show(self):
+        await self._update_message()
+
+    def add_run(self, title: str) -> "RunProgressReporter":
+        rpr = RunProgressReporterDiscord(self, self.interaction, title)
+        self.runs.append(rpr)
+        return rpr
+
+    def make_message(self):
+        formatted_runs = []
+        for run in self.runs:
+            formatted_runs.append(run.get_message())
+
+        return str.join("\n\n", [f"# {self.header}"] + formatted_runs)
+
+    async def _update_message(self):
+        if self.interaction is None:
+            return
+
+        await self.interaction.edit_original_response(content=self.make_message(), view=None)
+
+
+class RunProgressReporterDiscord(RunProgressReporter):
+    def __init__(
+        self,
+        root: MultiProgressReporter,
+        interaction: discord.Interaction,
+        title: str,
+    ):
+        super().__init__(title=title)
+        self.root = root
+        self.interaction = interaction
+
+    async def _update_message(self):
+        await self.root._update_message()
+
+    async def display_report(self, title: str, report: RunResultReport):
+        thread = await self.interaction.channel.create_thread(
+            name=title,
+            type=discord.ChannelType.private_thread,
+            auto_archive_duration=1440,
+        )
+        await thread.add_user(self.interaction.user)
+        message = ""
+        for part in report.data:
+            if isinstance(part, Text):
+                if len(message) + len(part.text) > 1900:
+                    await thread.send(message)
+                    message = ""
+                message += part.text
+            elif isinstance(part, Log):
+                message = await _send_split_log(thread, message, part.header, part.content)
+
+        if len(message) > 0:
+            await thread.send(message)
+
+        await self.push(f"See results at {thread.jump_url}")

--- a/src/discord-cluster-manager/discord_utils.py
+++ b/src/discord-cluster-manager/discord_utils.py
@@ -1,0 +1,105 @@
+import functools
+import logging
+
+import discord
+from utils import KernelBotError, setup_logging
+
+logger = setup_logging(__name__)
+
+
+def with_error_handling(f: callable):
+    @functools.wraps(f)
+    async def wrap(self, interaction: discord.Interaction, *args, **kwargs):
+        try:
+            await f(self, interaction, *args, **kwargs)
+        except KernelBotError as e:
+            await send_discord_message(
+                interaction,
+                str(e),
+                ephemeral=True,
+            )
+        except Exception as e:
+            logging.exception("Unhandled exception %s", e, exc_info=e)
+            await send_discord_message(
+                interaction,
+                "An unexpected error occurred. Please report this to the developers.",
+                ephemeral=True,
+            )
+
+    return wrap
+
+
+async def get_user_from_id(bot, id) -> str:
+    with bot.leaderboard_db as db:
+        return db.get_user_from_id(id) or id
+
+
+async def send_discord_message(
+    interaction: discord.Interaction, msg: str, *, ephemeral=False, **kwargs
+) -> None:
+    """
+    To get around response messages in slash commands that are
+    called externally, send a message using the followup.
+    """
+    if interaction.response.is_done():
+        await interaction.followup.send(msg, ephemeral=ephemeral, **kwargs)
+    else:
+        await interaction.response.send_message(msg, ephemeral=ephemeral, **kwargs)
+
+
+async def send_logs(thread: discord.Thread, logs: str) -> None:
+    """Send logs to a Discord thread, splitting by lines and respecting Discord's character limit.
+
+    Args:
+        thread: The Discord thread to send logs to
+        logs: The log string to send
+    """
+    # Split logs into lines
+    log_lines = logs.splitlines()
+
+    current_chunk = []
+    current_length = 0
+
+    for line in log_lines:
+        # Add 1 for the newline character
+        line_length = len(line) + 1
+
+        # If adding this line would exceed Discord's limit, send current chunk
+        if current_length + line_length > 1990:  # Leave room for code block markers
+            if current_chunk:
+                chunk_text = "\n".join(current_chunk)
+                await thread.send(f"```\n{chunk_text}\n```")
+                current_chunk = []
+                current_length = 0
+
+        current_chunk.append(line)
+        current_length += line_length
+
+    # Send any remaining lines
+    if current_chunk:
+        chunk_text = "\n".join(current_chunk)
+        await thread.send(f"```\n{chunk_text}\n```")
+
+
+async def leaderboard_name_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> list[discord.app_commands.Choice[str]]:
+    """Return leaderboard names that match the current typed name"""
+    try:
+        bot = interaction.client
+        name_cache = bot.leaderboard_db.name_cache
+        cached_value = name_cache[current]
+        if cached_value is not None:
+            return cached_value
+
+        with bot.leaderboard_db as db:
+            leaderboards = db.get_leaderboard_names()
+        filtered = [lb for lb in leaderboards if current.lower() in lb.lower()]
+        name_cache[current] = [
+            discord.app_commands.Choice(name=name, value=name) for name in filtered[:25]
+        ]
+        return name_cache[current]
+    except Exception as e:
+        logger.exception("Error in leaderboard autocomplete", exc_info=e)
+        return []

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -5,10 +5,6 @@ import logging
 from typing import List, Optional
 
 import psycopg2
-from env import (
-    DATABASE_URL,
-    DISABLE_SSL,
-)
 from run_eval import CompileResult, RunResult, SystemInfo
 from task import LeaderboardTask
 from utils import (
@@ -25,7 +21,9 @@ logger = setup_logging(__name__)
 
 
 class LeaderboardDB:
-    def __init__(self, host: str, database: str, user: str, password: str, port: str = "5432"):
+    def __init__(
+        self, host: str, database: str, user: str, password: str, port: str, url: str, ssl_mode: str
+    ):
         """Initialize database connection parameters"""
         self.connection_params = {
             "host": host,
@@ -34,6 +32,8 @@ class LeaderboardDB:
             "password": password,
             "port": port,
         }
+        self.url = url
+        self.ssl_mode = ssl_mode
         self.connection: Optional[psycopg2.extensions.connection] = None
         self.refcount: int = 0
         self.cursor: Optional[psycopg2.extensions.cursor] = None
@@ -43,8 +43,8 @@ class LeaderboardDB:
         """Establish connection to the database"""
         try:
             self.connection = (
-                psycopg2.connect(DATABASE_URL, sslmode="require" if not DISABLE_SSL else "disable")
-                if DATABASE_URL
+                psycopg2.connect(self.url, sslmode=self.ssl_mode)
+                if self.url
                 else psycopg2.connect(**self.connection_params)
             )
             self.cursor = self.connection.cursor()

--- a/src/discord-cluster-manager/leaderboard_db.py
+++ b/src/discord-cluster-manager/leaderboard_db.py
@@ -1,7 +1,6 @@
 import dataclasses
 import datetime
 import json
-import logging
 from typing import List, NotRequired, Optional, TypedDict
 
 import psycopg2
@@ -507,7 +506,7 @@ class LeaderboardDB:
         try:
             return self._generate_stats(last_day)
         except Exception as e:
-            logging.exception("error generating stats", exc_info=e)
+            logger.exception("error generating stats", exc_info=e)
             raise
 
     def _generate_runner_stats(self, last_day: bool = False):

--- a/src/discord-cluster-manager/submission.py
+++ b/src/discord-cluster-manager/submission.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from typing import Optional, Union
 
 from better_profanity import profanity
-from leaderboard_db import LeaderboardDB
+from leaderboard_db import LeaderboardDB, LeaderboardItem
 from task import LeaderboardTask
-from utils import KernelBotError, LeaderboardItem
+from utils import KernelBotError
 
 
 @dataclasses.dataclass

--- a/src/discord-cluster-manager/ui/misc.py
+++ b/src/discord-cluster-manager/ui/misc.py
@@ -2,7 +2,8 @@ from typing import Awaitable, Callable
 
 import discord
 from discord import Interaction, SelectOption, ui
-from utils import KernelBotError, send_discord_message
+from discord_utils import send_discord_message
+from utils import KernelBotError
 
 
 class GPUSelectionView(ui.View):

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -1,13 +1,9 @@
 import functools
 import logging
 import subprocess
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 import discord
-from consts import Language, SubmissionMode
-
-if TYPE_CHECKING:
-    from task import LeaderboardTask
 
 
 def setup_logging(name: Optional[str] = None):
@@ -176,76 +172,6 @@ class LRUCache:
         """
         self._cache.clear()
         self._q.clear()
-
-
-def build_task_config(
-    task: "LeaderboardTask" = None,
-    submission_content: str = None,
-    arch: str = None,
-    mode: SubmissionMode = None,
-) -> dict:
-    if task is None:
-        assert mode == SubmissionMode.SCRIPT
-        # TODO detect language
-        lang = "py"
-
-        config = {
-            "lang": lang,
-            "arch": arch,
-        }
-
-        eval_name = {"py": "eval.py", "cu": "eval.cu"}[lang]
-
-        if lang == "py":
-            config["main"] = "eval.py"
-
-        return {
-            **config,
-            "sources": {
-                eval_name: submission_content,
-            },
-        }
-    else:
-        all_files = {}
-        for n, c in task.files.items():
-            if c == "@SUBMISSION@":
-                all_files[n] = submission_content
-            else:
-                all_files[n] = c
-
-        common = {
-            "lang": task.lang.value,
-            "arch": arch,
-            "benchmarks": task.benchmarks,
-            "tests": task.tests,
-            "mode": mode.value,
-            "test_timeout": task.test_timeout,
-            "benchmark_timeout": task.benchmark_timeout,
-            "ranked_timeout": task.ranked_timeout,
-            "ranking_by": task.ranking_by.value,
-            "seed": task.seed,
-        }
-
-        if task.lang == Language.Python:
-            return {
-                "main": task.config.main,
-                "sources": all_files,
-                **common,
-            }
-        else:
-            sources = {}
-            headers = {}
-            for f in all_files:
-                if f in task.config.sources:
-                    sources[f] = all_files[f]
-                else:
-                    headers[f] = all_files[f]
-
-            return {
-                "sources": sources,
-                "headers": headers,
-                "include_dirs": task.config.include_dirs,
-            }
 
 
 def format_time(value: float | str, err: Optional[float | str] = None, scale=None):  # noqa: C901

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -1,9 +1,6 @@
-import functools
 import logging
 import subprocess
 from typing import Any, Optional
-
-import discord
 
 
 def setup_logging(name: Optional[str] = None):
@@ -24,31 +21,6 @@ def setup_logging(name: Optional[str] = None):
         logger.addHandler(console_handler)
 
     return logger
-
-
-logger = setup_logging(__name__)
-
-
-def with_error_handling(f: callable):
-    @functools.wraps(f)
-    async def wrap(self, interaction: discord.Interaction, *args, **kwargs):
-        try:
-            await f(self, interaction, *args, **kwargs)
-        except KernelBotError as e:
-            await send_discord_message(
-                interaction,
-                str(e),
-                ephemeral=True,
-            )
-        except Exception as e:
-            logging.exception("Unhandled exception %s", e, exc_info=e)
-            await send_discord_message(
-                interaction,
-                "An unexpected error occurred. Please report this to the developers.",
-                ephemeral=True,
-            )
-
-    return wrap
 
 
 class KernelBotError(Exception):
@@ -73,58 +45,6 @@ def get_github_branch_name():
         return result.stdout.strip().split("/", 1)[1]
     except subprocess.CalledProcessError:
         return "main"
-
-
-async def get_user_from_id(bot, id) -> str:
-    with bot.leaderboard_db as db:
-        return db.get_user_from_id(id) or id
-
-
-async def send_discord_message(
-    interaction: discord.Interaction, msg: str, *, ephemeral=False, **kwargs
-) -> None:
-    """
-    To get around response messages in slash commands that are
-    called externally, send a message using the followup.
-    """
-    if interaction.response.is_done():
-        await interaction.followup.send(msg, ephemeral=ephemeral, **kwargs)
-    else:
-        await interaction.response.send_message(msg, ephemeral=ephemeral, **kwargs)
-
-
-async def send_logs(thread: discord.Thread, logs: str) -> None:
-    """Send logs to a Discord thread, splitting by lines and respecting Discord's character limit.
-
-    Args:
-        thread: The Discord thread to send logs to
-        logs: The log string to send
-    """
-    # Split logs into lines
-    log_lines = logs.splitlines()
-
-    current_chunk = []
-    current_length = 0
-
-    for line in log_lines:
-        # Add 1 for the newline character
-        line_length = len(line) + 1
-
-        # If adding this line would exceed Discord's limit, send current chunk
-        if current_length + line_length > 1990:  # Leave room for code block markers
-            if current_chunk:
-                chunk_text = "\n".join(current_chunk)
-                await thread.send(f"```\n{chunk_text}\n```")
-                current_chunk = []
-                current_length = 0
-
-        current_chunk.append(line)
-        current_length += line_length
-
-    # Send any remaining lines
-    if current_chunk:
-        chunk_text = "\n".join(current_chunk)
-        await thread.send(f"```\n{chunk_text}\n```")
 
 
 class LRUCache:
@@ -215,27 +135,3 @@ def format_time(value: float | str, err: Optional[float | str] = None, scale=Non
             return f"{value:.0f} ± {err:.1f} {unit}"
         else:
             return f"{value:.0f} {unit}"
-
-
-async def leaderboard_name_autocomplete(
-    interaction: discord.Interaction,
-    current: str,
-) -> list[discord.app_commands.Choice[str]]:
-    """Return leaderboard names that match the current typed name"""
-    try:
-        bot = interaction.client
-        name_cache = bot.leaderboard_db.name_cache
-        cached_value = name_cache[current]
-        if cached_value is not None:
-            return cached_value
-
-        with bot.leaderboard_db as db:
-            leaderboards = db.get_leaderboard_names()
-        filtered = [lb for lb in leaderboards if current.lower() in lb.lower()]
-        name_cache[current] = [
-            discord.app_commands.Choice(name=name, value=name) for name in filtered[:25]
-        ]
-        return name_cache[current]
-    except Exception as e:
-        logger.exception("Error in leaderboard autocomplete", exc_info=e)
-        return []

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -1,8 +1,7 @@
-import datetime
 import functools
 import logging
 import subprocess
-from typing import TYPE_CHECKING, Any, List, NotRequired, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Optional
 
 import discord
 from consts import Language, SubmissionMode
@@ -177,55 +176,6 @@ class LRUCache:
         """
         self._cache.clear()
         self._q.clear()
-
-
-class LeaderboardItem(TypedDict):
-    id: int
-    name: str
-    creator_id: int
-    deadline: datetime.datetime
-    task: "LeaderboardTask"
-    gpu_types: List[str]
-    forum_id: int
-    secret_seed: NotRequired[int]
-
-
-class LeaderboardRankedEntry(TypedDict):
-    submission_id: int
-    rank: int
-    submission_name: str
-    submission_time: datetime.datetime
-    submission_score: float
-    leaderboard_name: str
-    user_id: int
-    user_name: str
-    gpu_type: str
-
-
-class RunItem(TypedDict):
-    start_time: datetime.datetime
-    end_time: datetime.datetime
-    mode: str
-    secret: bool
-    runner: str
-    score: Optional[float]
-    passed: bool
-    compilation: dict
-    meta: dict
-    result: dict
-    system: dict
-
-
-class SubmissionItem(TypedDict):
-    submission_id: int
-    leaderboard_id: int
-    leaderboard_name: str
-    file_name: str
-    user_id: int
-    submission_time: datetime.datetime
-    done: bool
-    code: str
-    runs: List[RunItem]
 
 
 def build_task_config(

--- a/src/discord-cluster-manager/utils.py
+++ b/src/discord-cluster-manager/utils.py
@@ -135,3 +135,10 @@ def format_time(value: float | str, err: Optional[float | str] = None, scale=Non
             return f"{value:.0f} ± {err:.1f} {unit}"
         else:
             return f"{value:.0f} {unit}"
+
+
+def limit_length(text: str, maxlen: int):
+    if len(text) > maxlen:
+        return text[: maxlen - 6] + " [...]"
+    else:
+        return text


### PR DESCRIPTION
In preparation for further cleanups, this PR tries to disentangle our files so there is less (direct and indirect) importing of discord happening.

* db is not independent from env
* db helper typedefs are now in db file (not 100% sure about that one, but imo a better place than "utils")
* instead of a global, the db stores the LRU cache as a member
* moved all utilities that interact with discord into a separate file

This should lay the groundwork so that we can make a libkernelbot python package that is completely independent from discord, and gets imported by the bot. Once we have this, we can start moving more functionality into this lib (looking at you, `reports.py`)

The PR contains a bunch of changes, but each individual commit should be fairly straightforward.