### PR TITLE
add a backend class that handles db and submission triggering

### DIFF
--- a/src/discord-cluster-manager/api/main.py
+++ b/src/discord-cluster-manager/api/main.py
@@ -227,7 +227,6 @@ async def cli_auth(auth_provider: str, code: str, state: str, db_context=Depends
 
 async def _stream_submission_response(
     submission_request: SubmissionRequest,
-    user_info: dict,
     submission_mode_enum: SubmissionMode,
     backend: KernelBackend,
 ):
@@ -237,7 +236,6 @@ async def _stream_submission_response(
         task = asyncio.create_task(
             _run_submission(
                 submission_request,
-                user_info,
                 submission_mode_enum,
                 backend,
             )
@@ -398,6 +396,7 @@ async def run_submission(  # noqa: C901
             code=submission_code,
             file_name=file.filename or "submission.py",
             user_id=user_id,
+            user_name=user_name,
             gpus=[gpu_type],
             leaderboard=leaderboard_name,
         )
@@ -412,7 +411,6 @@ async def run_submission(  # noqa: C901
 
     generator = _stream_submission_response(
         submission_request=submission_request,
-        user_info={"user_id": user_id, "user_name": user_name},
         submission_mode_enum=submission_mode_enum,
         backend=backend_instance,
     )

--- a/src/discord-cluster-manager/backend.py
+++ b/src/discord-cluster-manager/backend.py
@@ -1,0 +1,189 @@
+import copy
+import math
+from typing import Optional
+
+import env
+from consts import GPU, GPU_TO_SM, RankCriterion, SubmissionMode
+from launchers import Launcher
+from leaderboard_db import LeaderboardDB
+from report import RunProgressReporter, generate_report, make_short_report
+from run_eval import FullResult
+from task import LeaderboardTask, build_task_config
+from utils import KernelBotError, setup_logging
+
+logger = setup_logging(__name__)
+
+
+class KernelBackend:
+    def __init__(
+        self,
+        debug_mode=False,
+    ):
+        self.debug_mode = debug_mode
+        self.db = LeaderboardDB(
+            env.POSTGRES_HOST,
+            env.POSTGRES_DATABASE,
+            env.POSTGRES_USER,
+            env.POSTGRES_PASSWORD,
+            env.POSTGRES_PORT,
+            url=env.DATABASE_URL,
+            ssl_mode="require" if not env.DISABLE_SSL else "disable",
+        )
+
+        try:
+            if not self.db.connect():
+                logger.error("Could not connect to database, shutting down")
+                exit(1)
+        finally:
+            self.db.disconnect()
+
+        self.accepts_jobs = True
+        self.launcher_map = {}
+
+    def register_launcher(self, launcher: Launcher):
+        for gpu in launcher.gpus:
+            self.launcher_map[gpu.value] = launcher
+
+    async def submit_leaderboard(  # noqa: C901
+        self,
+        submission_id: int,
+        code: str,
+        name: str,
+        gpu_type: GPU,
+        reporter: RunProgressReporter,
+        task: LeaderboardTask,
+        mode: SubmissionMode,
+        seed: Optional[int],
+    ) -> Optional[FullResult]:
+        """
+        Function invoked by `leaderboard_cog` to handle a leaderboard run.
+        """
+        if seed is not None:
+            # careful, we've got a reference here
+            # that is shared with the other run
+            # invocations.
+            task = copy.copy(task)
+            task.seed = seed
+
+        result = await self.handle_submission(
+            gpu_type,
+            reporter,
+            code=code,
+            name=name,
+            task=task,
+            mode=mode,
+            submission_id=submission_id,
+        )
+
+        if result.success:
+            score = None
+            if (
+                "leaderboard" in result.runs
+                and result.runs["leaderboard"].run.success
+                and result.runs["leaderboard"].run.passed
+            ):
+                score = 0.0
+                num_benchmarks = int(result.runs["leaderboard"].run.result["benchmark-count"])
+                if task.ranking_by == RankCriterion.LAST:
+                    if num_benchmarks != 1:
+                        logger.error(
+                            "Ranked submission error for submission %d ranking_by is `last`, "
+                            "but got %d benchmarks",
+                            submission_id,
+                            num_benchmarks,
+                        )
+                        raise KernelBotError(
+                            f"Expected submission to have exactly one benchmark,"
+                            f"got {num_benchmarks}."
+                        )
+                    score = float(result.runs["leaderboard"].run.result["benchmark.0.mean"]) / 1e9
+                else:
+                    scores = []
+                    for i in range(num_benchmarks):
+                        scores.append(
+                            float(result.runs["leaderboard"].run.result[f"benchmark.{i}.mean"])
+                            / 1e9
+                        )
+                    if task.ranking_by == RankCriterion.MEAN:
+                        score = sum(scores) / len(scores)
+                    elif task.ranking_by == RankCriterion.GEOM:
+                        score = math.pow(math.prod(scores), 1.0 / num_benchmarks)
+
+            # verifyruns uses a fake submission id of -1
+            if submission_id != -1:
+                with self.db as db:
+                    for key, value in result.runs.items():
+                        db.create_submission_run(
+                            submission_id,
+                            value.start,
+                            value.end,
+                            mode=key,
+                            runner=gpu_type.name,
+                            score=None if key != "leaderboard" else score,
+                            secret=mode == SubmissionMode.PRIVATE,
+                            compilation=value.compilation,
+                            result=value.run,
+                            system=result.system,
+                        )
+
+        return result
+
+    async def handle_submission(
+        self,
+        gpu_type: GPU,
+        reporter: RunProgressReporter,
+        code: str,
+        name: str,
+        task: Optional[LeaderboardTask],
+        mode: SubmissionMode,
+        submission_id: int = -1,
+    ) -> Optional[FullResult]:
+        """
+        Generic function to handle code submissions.
+        Args:
+            gpu_type: Which GPU to run on.
+            code: Submitted code
+            name: File name of the submission; used to infer code's language
+            task: Task specification, of provided
+            submission_id: ID of the submission, only used for display purposes
+
+        Returns:
+            if successful, returns the result of the run.
+        """
+        launcher = self.launcher_map[gpu_type.value]
+        config = build_task_config(
+            task=task, submission_content=code, arch=self._get_arch(gpu_type), mode=mode
+        )
+
+        logger.info("submitting task to runner %s", launcher.name)
+
+        result = await launcher.run_submission(config, gpu_type, reporter)
+
+        if not result.success:
+            await reporter.update_title(reporter.title + " ❌ failure")
+            await reporter.push(result.error)
+            return result
+        else:
+            await reporter.update_title(reporter.title + " ✅ success")
+
+        short_report = make_short_report(
+            result.runs, full=mode in [SubmissionMode.PRIVATE, SubmissionMode.LEADERBOARD]
+        )
+        await reporter.push(short_report)
+        if mode != SubmissionMode.PRIVATE:
+            try:
+                # does the last message of the short report start with ✅ or ❌?
+                verdict = short_report[-1][0]
+                id_str = f"{verdict}" if submission_id == -1 else f"{verdict} #{submission_id}"
+                await reporter.display_report(
+                    f"{id_str} {name} on {gpu_type.name} ({launcher.name})",
+                    generate_report(result),
+                )
+            except Exception as E:
+                logger.error("Error generating report. Result: %s", result, exc_info=E)
+                raise
+
+        return result
+
+    def _get_arch(self, gpu_type: GPU):
+        return GPU_TO_SM[gpu_type.name]

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -482,7 +482,7 @@ class AdminCog(commands.Cog):
             )
             return
 
-        self.bot.accepts_jobs = False
+        self.bot.backend.accepts_jobs = False
         await send_discord_message(
             interaction, "Bot will refuse all future submissions!", ephemeral=True
         )
@@ -498,7 +498,7 @@ class AdminCog(commands.Cog):
             )
             return
 
-        self.bot.accepts_jobs = True
+        self.bot.backend.accepts_jobs = True
         await send_discord_message(
             interaction, "Bot will accept submissions again!", ephemeral=True
         )

--- a/src/discord-cluster-manager/cogs/leaderboard_cog.py
+++ b/src/discord-cluster-manager/cogs/leaderboard_cog.py
@@ -107,7 +107,7 @@ class LeaderboardSubmitCog(app_commands.Group):
 
         selected_gpus = [get_gpu_by_name(gpu) for gpu in selected_gpus]
 
-        command = self.bot.get_cog("SubmitCog").submit_leaderboard
+        command = self.bot.backend.submit_leaderboard
 
         user_name = interaction.user.global_name or interaction.user.name
         # Create a submission entry in the database
@@ -232,7 +232,7 @@ class LeaderboardSubmitCog(app_commands.Group):
         mode: SubmissionMode,
         gpu: Optional[str],
     ):
-        if not self.bot.accepts_jobs:
+        if not self.bot.backend.accepts_jobs:
             await send_discord_message(
                 interaction,
                 "The bot is currently not accepting any new submissions, please try again later.",

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -9,7 +9,7 @@ import discord
 from consts import SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.ext import commands
-from discord_reporter import MultiProgressReporter
+from discord_reporter import MultiProgressReporterDiscord
 from discord_utils import send_discord_message, with_error_handling
 from utils import (
     setup_logging,
@@ -70,7 +70,7 @@ class SubmitCog(commands.Cog):
         """
         Function invoked by the `run` command to run a single script.
         """
-        reporter = MultiProgressReporter(interaction, "Script run")
+        reporter = MultiProgressReporterDiscord(interaction, "Script run")
         rep = reporter.add_run(f"{gpu_type.name}")
         await reporter.show()
         gpu_type = get_gpu_by_name(gpu_type.name)

--- a/src/discord-cluster-manager/cogs/submit_cog.py
+++ b/src/discord-cluster-manager/cogs/submit_cog.py
@@ -1,5 +1,3 @@
-import copy
-import math
 from typing import TYPE_CHECKING, Optional
 
 from launchers import Launcher
@@ -8,20 +6,12 @@ if TYPE_CHECKING:
     from bot import ClusterBot
 
 import discord
-from consts import GPU, GPU_TO_SM, RankCriterion, SubmissionMode, get_gpu_by_name
+from consts import SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.ext import commands
 from discord_reporter import MultiProgressReporter
 from discord_utils import send_discord_message, with_error_handling
-from report import (
-    RunProgressReporter,
-    generate_report,
-    make_short_report,
-)
-from run_eval import FullResult
-from task import LeaderboardTask, build_task_config
 from utils import (
-    KernelBotError,
     setup_logging,
 )
 
@@ -37,7 +27,12 @@ class SubmitCog(commands.Cog):
 
     def __init__(self, bot):
         self.bot: ClusterBot = bot
-        self.launcher_map = {}
+        handled_launchers = set()
+        for launcher in self.bot.backend.launcher_map.values():
+            if id(launcher) in handled_launchers:
+                continue
+            handled_launchers.add(id(launcher))
+            self.register_launcher(launcher)
 
     def register_launcher(self, launcher: Launcher):
         choices = [app_commands.Choice(name=c.name, value=c.value) for c in launcher.gpus]
@@ -65,93 +60,6 @@ class SubmitCog(commands.Cog):
                 name=launcher.name.lower(), description=f"Run a script using {launcher.name}"
             )(run)
 
-        for gpu in launcher.gpus:
-            self.launcher_map[gpu.value] = launcher
-
-    async def submit_leaderboard(  # noqa: C901
-        self,
-        submission_id: int,
-        code: str,
-        name: str,
-        gpu_type: GPU,
-        reporter: RunProgressReporter,
-        task: LeaderboardTask,
-        mode: SubmissionMode,
-        seed: Optional[int],
-    ) -> Optional[FullResult]:
-        """
-        Function invoked by `leaderboard_cog` to handle a leaderboard run.
-        """
-        if seed is not None:
-            # careful, we've got a reference here
-            # that is shared with the other run
-            # invocations.
-            task = copy.copy(task)
-            task.seed = seed
-
-        result = await self._handle_submission(
-            gpu_type,
-            reporter,
-            code=code,
-            name=name,
-            task=task,
-            mode=mode,
-            submission_id=submission_id,
-        )
-
-        if result.success:
-            score = None
-            if (
-                "leaderboard" in result.runs
-                and result.runs["leaderboard"].run.success
-                and result.runs["leaderboard"].run.passed
-            ):
-                score = 0.0
-                num_benchmarks = int(result.runs["leaderboard"].run.result["benchmark-count"])
-                if task.ranking_by == RankCriterion.LAST:
-                    if num_benchmarks != 1:
-                        logger.error(
-                            "Ranked submission error for submission %d ranking_by is `last`, "
-                            "but got %d benchmarks",
-                            submission_id,
-                            num_benchmarks,
-                        )
-                        raise KernelBotError(
-                            f"Expected submission to have exactly one benchmark,"
-                            f"got {num_benchmarks}."
-                        )
-                    score = float(result.runs["leaderboard"].run.result["benchmark.0.mean"]) / 1e9
-                else:
-                    scores = []
-                    for i in range(num_benchmarks):
-                        scores.append(
-                            float(result.runs["leaderboard"].run.result[f"benchmark.{i}.mean"])
-                            / 1e9
-                        )
-                    if task.ranking_by == RankCriterion.MEAN:
-                        score = sum(scores) / len(scores)
-                    elif task.ranking_by == RankCriterion.GEOM:
-                        score = math.pow(math.prod(scores), 1.0 / num_benchmarks)
-
-            # verifyruns uses a fake submission id of -1
-            if submission_id != -1:
-                with self.bot.leaderboard_db as db:
-                    for key, value in result.runs.items():
-                        db.create_submission_run(
-                            submission_id,
-                            value.start,
-                            value.end,
-                            mode=key,
-                            runner=gpu_type.name,
-                            score=None if key != "leaderboard" else score,
-                            secret=mode == SubmissionMode.PRIVATE,
-                            compilation=value.compilation,
-                            result=value.run,
-                            system=result.system,
-                        )
-
-        return result
-
     @with_error_handling
     async def run_script(
         self,
@@ -170,7 +78,7 @@ class SubmitCog(commands.Cog):
         if script_content is None:
             return
 
-        await self._handle_submission(
+        await self.bot.backend.handle_submission(
             gpu_type,
             rep,
             code=script_content,
@@ -178,64 +86,6 @@ class SubmitCog(commands.Cog):
             task=None,
             mode=SubmissionMode.SCRIPT,
         )
-
-    async def _handle_submission(
-        self,
-        gpu_type: GPU,
-        reporter: RunProgressReporter,
-        code: str,
-        name: str,
-        task: Optional[LeaderboardTask],
-        mode: SubmissionMode,
-        submission_id: int = -1,
-    ) -> Optional[FullResult]:
-        """
-        Generic function to handle code submissions.
-        Args:
-            interaction: Interaction that started this command.
-            gpu_type: Which GPU to run on.
-            code: Submitted code
-            name: File name of the submission; used to infer code's language
-            task: Task specification, of provided
-            submission_id: ID of the submission, only used for display purposes
-
-        Returns:
-            if successful, returns the result of the run.
-        """
-        launcher = self.launcher_map[gpu_type.value]
-        config = build_task_config(
-            task=task, submission_content=code, arch=self._get_arch(gpu_type), mode=mode
-        )
-
-        logger.info("submitting task to runner %s", launcher.name)
-
-        result = await launcher.run_submission(config, gpu_type, reporter)
-
-        if not result.success:
-            await reporter.update_title(reporter.title + " ❌ failure")
-            await reporter.push(result.error)
-            return result
-        else:
-            await reporter.update_title(reporter.title + " ✅ success")
-
-        short_report = make_short_report(
-            result.runs, full=mode in [SubmissionMode.PRIVATE, SubmissionMode.LEADERBOARD]
-        )
-        await reporter.push(short_report)
-        if mode != SubmissionMode.PRIVATE:
-            try:
-                # does the last message of the short report start with ✅ or ❌?
-                verdict = short_report[-1][0]
-                id_str = f"{verdict}" if submission_id == -1 else f"{verdict} #{submission_id}"
-                await reporter.display_report(
-                    f"{id_str} {name} on {gpu_type.name} ({launcher.name})",
-                    generate_report(result),
-                )
-            except Exception as E:
-                logger.error("Error generating report. Result: %s", result, exc_info=E)
-                raise
-
-        return result
 
     async def _validate_input_file(
         self,
@@ -252,6 +102,3 @@ class SubmitCog(commands.Cog):
                 ephemeral=True,
             )
             return None
-
-    def _get_arch(self, gpu_type: GPU):
-        return GPU_TO_SM[gpu_type.name]

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -13,7 +13,7 @@ from consts import GPU, SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.app_commands import Choice
 from discord.ext import commands
-from discord_reporter import MultiProgressReporter
+from discord_reporter import MultiProgressReporterDiscord
 from discord_utils import send_discord_message, with_error_handling
 from leaderboard_db import RunItem, SubmissionItem
 from task import make_task
@@ -291,7 +291,7 @@ class VerifyRunCog(commands.Cog):
             amd = get_gpu_by_name("mi300")
             t4 = get_gpu_by_name("T4")
 
-            reporter = MultiProgressReporter("Verifying")
+            reporter = MultiProgressReporterDiscord("Verifying")
             await reporter.show(interaction)
 
             results = await asyncio.gather(

--- a/src/discord-cluster-manager/cogs/verify_run_cog.py
+++ b/src/discord-cluster-manager/cogs/verify_run_cog.py
@@ -9,7 +9,6 @@ import discord
 import env
 from cogs import admin_cog
 from cogs.leaderboard_cog import LeaderboardSubmitCog
-from cogs.submit_cog import SubmitCog
 from consts import GPU, SubmissionMode, get_gpu_by_name
 from discord import app_commands
 from discord.app_commands import Choice
@@ -47,8 +46,7 @@ class VerifyRunCog(commands.Cog):
         self.bot = bot
 
     async def trigger_run(self, interaction: discord.Interaction, gpu: GPU, reporter, lang: str):
-        submit_cog: SubmitCog = self.bot.get_cog("SubmitCog")
-        submit_leaderboard = submit_cog.submit_leaderboard
+        submit_leaderboard = self.bot.backend.submit_leaderboard
 
         if lang == "py":
             sub_code = create_mock_attachment(
@@ -288,12 +286,6 @@ class VerifyRunCog(commands.Cog):
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
-
-            submit_cog = self.bot.get_cog("SubmitCog")
-
-            if not submit_cog:
-                await send_discord_message(interaction, "❌ SubmitCog not found!")
-                return
 
             nvidia = get_gpu_by_name("nvidia")
             amd = get_gpu_by_name("mi300")

--- a/src/discord-cluster-manager/discord_reporter.py
+++ b/src/discord-cluster-manager/discord_reporter.py
@@ -1,18 +1,19 @@
 import discord
 from discord_utils import _send_split_log
-from report import Log, RunProgressReporter, RunResultReport, Text
+from report import Log, MultiProgressReporter, RunProgressReporter, RunResultReport, Text
 
 
-class MultiProgressReporter:
-    def __init__(self, interaction: discord.Interaction, header: str):
-        self.header = header
+class MultiProgressReporterDiscord(MultiProgressReporter):
+    def __init__(self, interaction: discord.Interaction):
+        self.header = ""
         self.runs = []
         self.interaction = interaction
 
-    async def show(self):
+    async def show(self, title: str):
+        self.header = title
         await self._update_message()
 
-    def add_run(self, title: str) -> "RunProgressReporter":
+    def add_run(self, title: str) -> "RunProgressReporterDiscord":
         rpr = RunProgressReporterDiscord(self, self.interaction, title)
         self.runs.append(rpr)
         return rpr
@@ -34,7 +35,7 @@ class MultiProgressReporter:
 class RunProgressReporterDiscord(RunProgressReporter):
     def __init__(
         self,
-        root: MultiProgressReporter,
+        root: MultiProgressReporterDiscord,
         interaction: discord.Interaction,
         title: str,
     ):

--- a/src/discord-cluster-manager/report.py
+++ b/src/discord-cluster-manager/report.py
@@ -367,6 +367,17 @@ def generate_report(result: FullResult) -> RunResultReport:  # noqa: C901
     return report
 
 
+class MultiProgressReporter:
+    async def show(self, title: str):
+        raise NotImplementedError()
+
+    def add_run(self, title: str) -> "RunProgressReporter":
+        raise NotImplementedError()
+
+    def make_message(self):
+        raise NotImplementedError()
+
+
 class RunProgressReporter:
     def __init__(self, title: str):
         # short report

--- a/src/discord-cluster-manager/submission.py
+++ b/src/discord-cluster-manager/submission.py
@@ -15,6 +15,7 @@ class SubmissionRequest:
     code: str
     file_name: str
     user_id: int
+    user_name: str
     gpus: Union[None, str, list]
     leaderboard: Optional[str]
 


### PR DESCRIPTION
This moves the remaining critical bits of submission logic out of SubmitCog, which now only exists to submit the legacy  "run" commands; don't think we've ever used them, maybe just nuke them to get rid of the complexity?

There are still lots of submission-related things scattered and duplicated all across the codebase, but if i didn't miss anything, this should make it possible to write a new/additional main file that enables running the API without the discord bot being required.