### PR TITLE
Milestones V2

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,32 @@
+services:
+  postgres-test:
+    image: postgres:15
+    container_name: postgres_db_test
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: clusterdev
+    ports:
+      - "5433:5432"
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d clusterdev"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  migrate-test:
+    image: python:3.11-slim
+    depends_on:
+      postgres-test:
+        condition: service_healthy
+    volumes:
+      - ./src/migrations:/migrations
+    command: >
+      sh -c "
+        pip install yoyo-migrations psycopg2-binary &&
+        yoyo apply -b -d 'postgresql://postgres:postgres@postgres-test:5432/clusterdev' -v /migrations/ &&
+        yoyo list -d 'postgresql://postgres:postgres@postgres-test:5432/clusterdev' /migrations/
+      "
+    restart: "no"

--- a/examples/matmul_py/task.yml
+++ b/examples/matmul_py/task.yml
@@ -9,9 +9,15 @@ files:
 
 milestones:
   - {
-      "name": "pytorch reference",
-      "source": "submission.py",
-      "description": "PyTorch reference implementation as a performance baseline for matmul"
+      name: "pytorch",
+      source: "submission.py",
+      description: "PyTorch reference implementation as a performance baseline for matmul"
+    }
+  - {
+      name: "triton",
+      source: "triton_ref.py",
+      description: "Triton reference implementation as a performance baseline for matmul",
+      exclude_gpus: ['T4']
     }
 
 lang: "py"

--- a/examples/matmul_py/task.yml
+++ b/examples/matmul_py/task.yml
@@ -7,6 +7,13 @@ files:
   - {"name": "reference.py", "source": "reference.py"}
   - {"name": "eval.py", "source": "../eval.py"}
 
+milestones:
+  - {
+      "name": "pytorch reference",
+      "source": "submission.py",
+      "description": "PyTorch reference implementation as a performance baseline for matmul"
+    }
+
 lang: "py"
 
 description: |

--- a/examples/matmul_py/triton_ref.py
+++ b/examples/matmul_py/triton_ref.py
@@ -1,0 +1,127 @@
+#!POPCORN leaderboard matmul_py
+import triton
+import triton.language as tl
+import torch
+from task import input_t, output_t
+
+
+@triton.jit
+def matmul_kernel(
+    # Pointers to matrices
+    a_ptr, b_ptr, c_ptr,
+    # Matrix dimensions
+    M, N, K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 cache hit rates.
+    # See above `L2 Cache Optimizations` section for details.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    # See above `Pointer Arithmetic` section for details
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher precision.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        # Load the next block of A and B, generate a mask by checking the K dimension.
+        # If it is out of bounds, set it to 0.
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        # We accumulate along the K dimension.
+        accumulator += tl.dot(a, b)
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+    # You can fuse arbitrary activation functions here
+    # while the accumulator is still in FP32!
+    c = accumulator.to(tl.float16)
+
+    # -----------------------------------------------------------
+    # Write back the block of the output matrix C with masks.
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def triton_matmul(a, b):
+    # Check constraints.
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+    assert b.is_contiguous(), "Matrix B must be contiguous"
+    M, K = a.shape
+    K, N = b.shape
+    # Allocate output.
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    # 1D launch kernel where each block gets its own program.
+    grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
+    matmul_kernel[grid](
+        a, b, c,
+        M, N, K,
+        a.stride(0), a.stride(1),
+        b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+        BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32,
+        GROUP_SIZE_M=8,
+    )
+    return c
+
+
+def custom_kernel(data: input_t) -> output_t:
+    a, b = data
+    # Convert to torch tensors if they aren't already
+    if not isinstance(a, torch.Tensor):
+        a = torch.tensor(a, dtype=torch.float16).cuda()
+    if not isinstance(b, torch.Tensor):
+        b = torch.tensor(b, dtype=torch.float16).cuda()
+    
+    # Ensure tensors are on GPU and contiguous
+    if not a.is_cuda:
+        a = a.cuda()
+    if not b.is_cuda:
+        b = b.cuda()
+    
+    a = a.contiguous()
+    b = b.contiguous()
+    
+    # Use our custom Triton matmul
+    result = triton_matmul(a, b)
+    
+    # Convert back to the expected output format
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ relative_files = true
 exclude_lines = [
    "pragma: no cover",
    "raise NotImplementedError",
+    # For now, don't require coverage of db errors
+   "except psycopg2.Error"
 ]
 
 [tool.pytest.ini_options]

--- a/src/kernelbot/cogs/admin_cog.py
+++ b/src/kernelbot/cogs/admin_cog.py
@@ -381,6 +381,7 @@ class AdminCog(commands.Cog):
                         milestone.name,
                         milestone.code,
                         description=milestone.description,
+                        exclude_gpus=milestone.exclude_gpus,
                     )
             except KernelBotError as e:
                 await send_discord_message(
@@ -457,10 +458,19 @@ class AdminCog(commands.Cog):
                 if gpu in [r["runner"] for r in existing_runs]:
                     await send_discord_message(
                         interaction,
-                        f"Skipping {gpu}; milestone run already exists.",
+                        f"Skipping {gpu} for {milestone['name']}; milestone run already exists.",
                         ephemeral=True,
                     )
                     continue
+
+                if gpu in milestone["exclude_gpus"]:
+                    await send_discord_message(
+                        interaction,
+                        f"Skipping {gpu} for {milestone['name']}; is excluded.",
+                        ephemeral=True,
+                    )
+                    continue
+
                 submit_tasks.append(
                     submit_milestone(
                         milestone,

--- a/src/kernelbot/cogs/admin_cog.py
+++ b/src/kernelbot/cogs/admin_cog.py
@@ -434,6 +434,13 @@ class AdminCog(commands.Cog):
 
             with backend.db as db:
                 for key, value in result.runs.items():
+                    # Only store LB runs in the database;
+                    # we still want to run test/benchmark to validate
+                    # that the code actually passes, but for all other
+                    # purposes we only need the leaderboard run
+                    if key != SubmissionMode.LEADERBOARD.value:
+                        continue
+
                     db.create_submission_run(
                         milestone=milestone["id"],
                         start=value.start,

--- a/src/kernelbot/cogs/leaderboard_cog.py
+++ b/src/kernelbot/cogs/leaderboard_cog.py
@@ -1,4 +1,3 @@
-import math
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import TYPE_CHECKING, List, Optional
@@ -23,9 +22,8 @@ from libkernelbot.leaderboard_db import (
     RunItem,
     SubmissionItem,
 )
-from libkernelbot.report import make_benchmark_log
 from libkernelbot.submission import SubmissionRequest, prepare_submission
-from libkernelbot.utils import format_time, run_item_to_run_result, setup_logging
+from libkernelbot.utils import format_time, setup_logging
 
 if TYPE_CHECKING:
     from kernelbot.main import ClusterBot
@@ -611,53 +609,10 @@ class LeaderboardCog(commands.Cog):
     ):
         await interaction.response.defer(ephemeral=True)
 
-        message = f"# Milestones for `{leaderboard_name}`\n"
-
         try:
-            with self.bot.leaderboard_db as db:
-                lb = db.get_leaderboard(leaderboard_name)
-                milestones = db.get_leaderboard_milestones(leaderboard_id=lb["id"])
-
-            if len(milestones) == 0:
-                await send_discord_message(
-                    interaction,
-                    f"Leaderboard `{leaderboard_name}` does not provide any milestones",
-                    ephemeral=True,
-                )
-                return
-
-            for milestone in milestones:
-                message += f"## {milestone['name']}\n"
-                message += milestone["description"] + "\n"
-                with self.bot.leaderboard_db as db:
-                    runs = db.get_runs_generic(milestone_id=milestone["id"])
-
-                runs = [r for r in runs if r["mode"] == SubmissionMode.LEADERBOARD.value]
-
-                if len(runs) == 0:
-                    message += "⚠️ No runs available. Maybe they haven't been triggered yet?\n"
-
-                if gpu is not None:
-                    runs = [r for r in runs if r["runner"] == gpu]
-                if len(runs) == 0:
-                    message += f"⚠️ No runs available for GPU {gpu}\n"
-
-                max_len = 0
-                min_val = float("inf")
-                for run in runs:
-                    max_len = max(max_len, len(run["runner"]))
-                    min_val = min(min_val, run["score"])
-
-                digits = max(0, 1 - math.floor(math.log10(min_val)))
-
-                message += "```\n"
-                for run in runs:
-                    message += f" {run['runner']:<{max_len}}: {run['score']:.{digits}f}\n"
-                message += "```\n\n"
-
             await send_discord_message(
                 interaction,
-                message,
+                self.bot.backend.get_milestone_overview(leaderboard_name, gpu),
                 ephemeral=True,
             )
 
@@ -685,41 +640,7 @@ class LeaderboardCog(commands.Cog):
         gpu: Optional[str] = None,
     ):
         await interaction.response.defer(ephemeral=True)
-        with self.bot.leaderboard_db as db:
-            lb = db.get_leaderboard(leaderboard_name)
-            milestones = db.get_leaderboard_milestones(leaderboard_id=lb["id"])
-
-        selected = None
-        for milestone in milestones:
-            if milestone["name"].lower() == milestone_name.lower():
-                selected = milestone
-                break
-
-        if selected is None:
-            await send_discord_message(
-                interaction,
-                f"Could not find milestone `{milestone_name}` for leaderboard `{leaderboard_name}`",
-                ephemeral=True,
-            )
-            return
-
-        with self.bot.leaderboard_db as db:
-            runs = db.get_runs_generic(milestone_id=selected["id"])
-
-        runs = [r for r in runs if r["mode"] == SubmissionMode.LEADERBOARD.value]
-
-        if len(runs) == 0:
-            await send_discord_message(
-                interaction,
-                f"⚠️ No runs available for milestone `{milestone_name}`."
-                "Maybe they haven't been triggered yet?",
-                ephemeral=True,
-            )
-            return
-
-        for run in runs:
-            log = make_benchmark_log(run_item_to_run_result(run))
-            message = f"{milestone_name} on {run['runner']}\n```{log}```\n"
+        for message in self.bot.backend.get_milestone_result(leaderboard_name, milestone_name, gpu):
             await send_discord_message(
                 interaction,
                 message,

--- a/src/libkernelbot/db_types.py
+++ b/src/libkernelbot/db_types.py
@@ -56,4 +56,12 @@ class SubmissionItem(TypedDict):
     runs: List[RunItem]
 
 
-__all__ = [LeaderboardItem, LeaderboardRankedEntry, RunItem, SubmissionItem]
+class MilestoneItem(TypedDict):
+    id: int
+    name: str
+    code: str
+    description: str
+    created_at: datetime.datetime
+
+
+__all__ = [LeaderboardItem, LeaderboardRankedEntry, RunItem, SubmissionItem, MilestoneItem]

--- a/src/libkernelbot/db_types.py
+++ b/src/libkernelbot/db_types.py
@@ -62,6 +62,7 @@ class MilestoneItem(TypedDict):
     code: str
     description: str
     created_at: datetime.datetime
+    exclude_gpus: list[str]
 
 
 __all__ = [LeaderboardItem, LeaderboardRankedEntry, RunItem, SubmissionItem, MilestoneItem]

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -784,7 +784,7 @@ class LeaderboardDB:
             user_id=submission[3],
             submission_time=submission[4],
             done=submission[5],
-            code=submission[6],
+            code=bytes(submission[6]).decode("utf-8"),
             runs=runs,
         )
 

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -310,6 +310,16 @@ class LeaderboardDB:
         )
         self.connection.commit()
 
+    def delete_milestones(self, leaderboard_id: int):
+        self.cursor.execute(
+            """
+            DELETE FROM leaderboard.milestones
+            WHERE leaderboard_id = %s;
+            """,
+            (leaderboard_id,),
+        )
+        self.connection.commit()
+
     def get_runs_generic(
         self, *, milestone_id: Optional[int] = None, submission_id: Optional[int] = None
     ) -> List["RunItem"]:

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -413,7 +413,7 @@ class LeaderboardDB:
     def get_leaderboard_names(self, active_only: bool = False) -> list[str]:
         if active_only:
             self.cursor.execute(
-                "SELECT name FROM leaderboard.leaderboard WHERE leaderboard.deadline < %s",
+                "SELECT name FROM leaderboard.leaderboard WHERE leaderboard.deadline > %s",
                 (datetime.datetime.now().astimezone(datetime.timezone.utc),),
             )
         else:

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -290,7 +290,7 @@ class LeaderboardDB:
             for row in self.cursor.fetchall()
         ]
 
-    def delete_milestone_runs(self, leaderboard_name: str):
+    def delete_milestone_runs(self, leaderboard_id: int):
         self.cursor.execute(
             """
             DELETE FROM leaderboard.runs
@@ -300,7 +300,7 @@ class LeaderboardDB:
                 WHERE leaderboard_id = %s
             );
             """,
-            (leaderboard_name,),
+            (leaderboard_id,),
         )
         self.connection.commit()
 

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -494,8 +494,8 @@ class LeaderboardDB:
             }
             self.cursor.execute(
                 """
-                INSERT INTO leaderboard.runs (submission_id, milestone_id, start_time, end_time, mode,
-                secret, runner, score, passed, compilation, meta, result, system_info
+                INSERT INTO leaderboard.runs (submission_id, milestone_id, start_time, end_time,
+                mode, secret, runner, score, passed, compilation, meta, result, system_info
                 )
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -29,6 +29,7 @@ class MilestoneData:
     name: str
     code: str
     description: str = ""
+    exclude_gpus: list[str] = dataclasses.field(default_factory=list)
 
 
 TestCaseType = Dict[str, Union[int, str]]

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -24,6 +24,13 @@ class PythonTaskData:
     main: str
 
 
+@dataclasses.dataclass
+class MilestoneData:
+    name: str
+    code: str
+    description: str = ""
+
+
 TestCaseType = Dict[str, Union[int, str]]
 
 
@@ -110,6 +117,7 @@ class LeaderboardDefinition:
     task: LeaderboardTask
     description: str = ""
     templates: dict[str, str] = dataclasses.field(default_factory=dict)
+    milestones: list[MilestoneData] = dataclasses.field(default_factory=list)
 
 
 def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
@@ -137,6 +145,12 @@ def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
         else:
             file_dict[name] = (root / source).read_text()
 
+    milestones = []
+    for milestone in raw.get("milestones", []):
+        milestone["code"] = (root / milestone["source"]).read_text()
+        del milestone["source"]
+        milestones.append(MilestoneData(**milestone))
+
     raw["files"] = file_dict
 
     # load template files
@@ -146,10 +160,14 @@ def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
         templates[lang] = (root / source).read_text()
 
     del raw["templates"]
+    del raw["milestones"]
     description = raw["description"]
     del raw["description"]
     task = LeaderboardTask.from_dict(raw)
-    return LeaderboardDefinition(task=task, templates=templates, description=description)
+
+    return LeaderboardDefinition(
+        task=task, templates=templates, milestones=milestones, description=description
+    )
 
 
 def build_task_config(

--- a/src/libkernelbot/utils.py
+++ b/src/libkernelbot/utils.py
@@ -2,6 +2,9 @@ import logging
 import subprocess
 from typing import Any, Optional
 
+from libkernelbot.db_types import RunItem
+from libkernelbot.run_eval import RunResult
+
 
 def setup_logging(name: Optional[str] = None):
     """Configure and setup logging for the application"""
@@ -144,3 +147,7 @@ def limit_length(text: str, maxlen: int):
         return text[: maxlen - 6] + " [...]"
     else:
         return text
+
+
+def run_item_to_run_result(item: RunItem) -> RunResult:
+    return RunResult(**item["meta"], result=item["result"], passed=item["passed"])

--- a/src/migrations/20250725_01_hwite-add-milestone-table.py
+++ b/src/migrations/20250725_01_hwite-add-milestone-table.py
@@ -11,7 +11,8 @@ steps = [
         """
          CREATE TABLE IF NOT EXISTS leaderboard.milestones (
              id SERIAL PRIMARY KEY,
-             leaderboard_id INTEGER NOT NULL REFERENCES leaderboard.leaderboard(id) ON DELETE CASCADE,
+             leaderboard_id INTEGER NOT NULL REFERENCES leaderboard.leaderboard(id)
+                ON DELETE CASCADE,
              name TEXT NOT NULL,
              code TEXT NOT NULL,
              description TEXT,

--- a/src/migrations/20250725_01_hwite-add-milestone-table.py
+++ b/src/migrations/20250725_01_hwite-add-milestone-table.py
@@ -1,0 +1,61 @@
+"""
+Add milestone table for better milestone tracking
+"""
+
+from yoyo import step
+
+__depends__ = {"20250617_01_c5mrF-task-split"}  # Update to latest migration
+
+steps = [
+    step(
+        """
+         CREATE TABLE IF NOT EXISTS leaderboard.milestones (
+             id SERIAL PRIMARY KEY,
+             leaderboard_id INTEGER NOT NULL REFERENCES leaderboard.leaderboard(id) ON DELETE CASCADE,
+             name TEXT NOT NULL,
+             code TEXT NOT NULL,
+             description TEXT,
+             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+             UNIQUE(leaderboard_id, name)
+         )
+         """,
+        "DROP TABLE leaderboard.milestones",
+    ),
+    step("CREATE INDEX ON leaderboard.milestones (leaderboard_id)"),
+    # add alternative ID column that references milestones;
+    # we don't really care about being careful preserving milestone
+    # runs, so we can simply DELETE CASCADE
+    step(
+        """
+        ALTER TABLE leaderboard.runs
+        ADD COLUMN milestone_id INTEGER REFERENCES leaderboard.milestones(id) ON DELETE CASCADE;
+        """,
+        "ALTER TABLE leaderboard.runs DROP COLUMN milestone_id;",
+    ),
+    # as we now have two possible ids, exactly one of them can be NULL
+    step(
+        "ALTER TABLE leaderboard.runs ALTER COLUMN submission_id DROP NOT NULL;",
+        """
+         DELETE FROM leaderboard.runs WHERE submission_id IS NULL;
+         ALTER TABLE leaderboard.runs ALTER COLUMN submission_id SET NOT NULL;
+         """,
+    ),
+    step(
+        """
+        ALTER TABLE leaderboard.runs
+        ADD CONSTRAINT runs_single_parent CHECK (
+            (submission_id IS NOT NULL AND milestone_id IS NULL) OR
+            (submission_id IS NULL AND milestone_id IS NOT NULL)
+        );
+        """,
+        "ALTER TABLE leaderboard.runs DROP CONSTRAINT runs_single_parent;",
+    ),
+    # ensure we have fast indexing for regular submissions
+    step(
+        """
+        CREATE INDEX IF NOT EXISTS runs_submission_id_idx ON leaderboard.runs(submission_id)
+        WHERE submission_id IS NOT NULL;
+        """,
+        "DROP INDEX IF EXISTS leaderboard.runs_submission_id_idx",
+    ),
+]

--- a/src/migrations/20250726_01_j9Q3S-milestone-exclude-column.py
+++ b/src/migrations/20250726_01_j9Q3S-milestone-exclude-column.py
@@ -1,0 +1,14 @@
+"""
+Adds an exclude column to indicate that a milestone is not compatible with certain GPUs
+"""
+
+from yoyo import step
+
+__depends__ = {"20250725_01_hwite-add-milestone-table"}
+
+steps = [
+    step(
+        "ALTER TABLE leaderboard.milestones ADD COLUMN exclude_gpus TEXT NOT NULL DEFAULT '';",
+        "ALTER TABLE leaderboard.milestones DROP COLUMN exclude_gpus;",
+    )
+]

--- a/src/migrations/20250728_01_Q3jso-fix-code-table.py
+++ b/src/migrations/20250728_01_Q3jso-fix-code-table.py
@@ -1,0 +1,93 @@
+"""
+Fix code table
+Uses bytea to store user-submitted code so we're safe to have any sort of special characters.
+"""
+
+from yoyo import step
+
+__depends__ = {"20250617_01_c5mrF-task-split"}
+
+"""
+Yoyo migration to convert code_files table from TEXT to BYTEA
+"""
+
+
+def convert_code_to_bytea(conn):
+    """Convert existing TEXT code to BYTEA and recalculate hashes"""
+    cursor = conn.cursor()
+
+    # Get all existing records
+    cursor.execute("SELECT id, old_code FROM leaderboard.code_files")
+    records = cursor.fetchall()
+
+    existing_codes = {}
+
+    for record_id, code_text in records:
+        # broken with the old code
+        if code_text.startswith("\\x"):
+            code_text = bytes.fromhex(code_text[2:]).decode("utf-8")
+        code_bytes = code_text.encode("utf-8")
+        # with the old broken code and experimentation, it is possible that we got some
+        # duplicates; fix this here
+        if code_bytes in existing_codes:
+            cursor.execute(
+                "UPDATE leaderboard.submission SET code_id = %s WHERE code_id = %s",
+                (existing_codes[code_bytes], record_id),
+            )
+            cursor.execute("DELETE FROM leaderboard.code_files WHERE id = %s", (record_id,))
+            continue
+
+        existing_codes[code_bytes] = record_id
+
+        # Update record with bytea and new hash
+        cursor.execute(
+            "UPDATE leaderboard.code_files SET code = %s WHERE id = %s", (code_bytes, record_id)
+        )
+
+
+def convert_bytea_to_text(conn):
+    """Convert existing BYTEA code to TEXT and recalculate hashes"""
+    cursor = conn.cursor()
+    # Get all existing records
+    cursor.execute("SELECT id, code FROM leaderboard.code_files")
+    records = cursor.fetchall()
+
+    for record_id, code_bytes in records:
+        code_text = bytes(code_bytes).decode("utf-8")
+        cursor.execute(
+            "UPDATE leaderboard.code_files SET old_code = %s WHERE id = %s",
+            (code_text.encode("utf-8"), record_id),
+        )
+
+
+steps = [
+    # prepare the table columns
+    step(
+        """
+        ALTER TABLE leaderboard.code_files DROP COLUMN hash;
+        ALTER TABLE leaderboard.code_files RENAME COLUMN code TO old_code;
+        ALTER TABLE leaderboard.code_files ADD COLUMN code BYTEA NOT NULL DEFAULT '';
+        """,
+        """
+         ALTER TABLE leaderboard.code_files DROP COLUMN code;
+         ALTER TABLE leaderboard.code_files RENAME COLUMN old_code TO code;
+         ALTER TABLE leaderboard.code_files ADD COLUMN hash TEXT
+            GENERATED ALWAYS AS (encode(sha256(code::bytea), 'hex')) STORED;
+         """,
+    ),
+    # run the conversion
+    step(convert_code_to_bytea, convert_bytea_to_text),
+    # clean up the table and reintroduce hashes
+    step(
+        """
+       ALTER TABLE leaderboard.code_files DROP COLUMN old_code;
+       ALTER TABLE leaderboard.code_files ADD COLUMN hash TEXT
+           GENERATED ALWAYS AS (encode(sha256(code), 'hex')) STORED NOT NULL UNIQUE;
+       ALTER TABLE leaderboard.code_files ALTER COLUMN code DROP DEFAULT;
+       """,
+        """
+         ALTER TABLE leaderboard.code_files ADD COLUMN old_code TEXT;
+         ALTER TABLE leaderboard.code_files DROP COLUMN hash;
+         """,
+    ),
+]

--- a/unit-tests/test_leaderboard_db.py
+++ b/unit-tests/test_leaderboard_db.py
@@ -1,0 +1,634 @@
+import copy
+import dataclasses
+import datetime
+import subprocess
+import time
+
+import pytest
+from test_report import sample_compile_result, sample_run_result, sample_system_info
+from test_task import task_directory
+
+from libkernelbot import leaderboard_db
+from libkernelbot.utils import KernelBotError
+
+DATABASE_URL = "postgresql://postgres:postgres@localhost:5433/clusterdev"
+
+
+@pytest.fixture(scope="module")
+def docker_compose():
+    """Start a test database and run migrations"""
+    subprocess.check_call(["docker", "compose", "-f", "docker-compose.test.yml", "up", "-d"])
+
+    try:
+        # Wait for migrations to finish
+        while True:
+            result = subprocess.run(
+                ["docker", "compose", "-f", "docker-compose.test.yml", "ps", "-q", "migrate-test"],
+                capture_output=True,
+                text=True,
+            )
+
+            if not result.stdout.strip():  # Container no longer exists
+                break
+            time.sleep(1)
+
+        # Check if migrations succeeded
+        logs = subprocess.run(
+            ["docker", "compose", "-f", "docker-compose.test.yml", "logs", "migrate-test"],
+            capture_output=True,
+            text=True,
+        )
+
+        if "error" in logs.stdout.lower():
+            raise Exception(f"Migrations failed: {logs.stdout}")
+
+        yield leaderboard_db.LeaderboardDB(
+            host="",
+            database="",
+            port="",
+            user="",
+            password="",
+            url=DATABASE_URL,
+            ssl_mode="disable",
+        )
+    finally:
+        subprocess.run(["docker", "compose", "-f", "docker-compose.test.yml", "down", "-v"])
+
+
+def _nuke_contents(db):
+    db.cursor.execute(
+        "TRUNCATE leaderboard.code_files, leaderboard.submission, leaderboard.runs, "
+        "leaderboard.leaderboard, leaderboard.user_info, leaderboard.templates, "
+        "leaderboard.gpu_type RESTART IDENTITY CASCADE"
+    )
+    db.connection.commit()
+
+
+@pytest.fixture()
+def database(docker_compose):
+    with docker_compose as db:
+        _nuke_contents(db)
+    yield docker_compose
+    with docker_compose as db:
+        _nuke_contents(db)
+
+
+def _submit_leaderboard(database, task_directory):
+    """
+    Creates a leaderboard called 'submit-leaderboard' and returns its ID.
+    """
+    from libkernelbot.task import make_task_definition
+
+    definition = make_task_definition(task_directory / "task.yml")
+    deadline = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
+
+    with database as db:
+        return db.create_leaderboard(
+            name="submit-leaderboard",
+            deadline=deadline,
+            definition=definition,
+            creator_id=1,
+            forum_id=5,
+            gpu_types=["A100", "H100"],
+        )
+
+
+@pytest.fixture()
+def submit_leaderboard(database, task_directory):
+    return _submit_leaderboard(database, task_directory)
+
+
+def _create_submission_run(
+    db: leaderboard_db.LeaderboardDB,
+    submission: int,
+    *,
+    start=None,
+    end=None,
+    mode="leaderboard",
+    secret=False,
+    runner="A100",
+    score=None,
+    compilation=None,
+    system=None,
+    result=None,
+):
+    """Creates a submission run with suitable default values"""
+    db.create_submission_run(
+        submission,
+        start=start or datetime.datetime.now(tz=datetime.timezone.utc),
+        end=end
+        or (datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=10)),
+        mode=mode,
+        secret=secret,
+        runner=runner,
+        score=score,
+        compilation=compilation or sample_compile_result(),
+        result=result or sample_run_result(),
+        system=system or sample_system_info(),
+    )
+
+
+def test_empty_db(database):
+    expected_error = "Leaderboard `does-not-exist` does not exist."
+    with database as db:
+        with pytest.raises(leaderboard_db.LeaderboardDoesNotExist, match=expected_error):
+            db.get_leaderboard("does-not-exist")
+        with pytest.raises(leaderboard_db.LeaderboardDoesNotExist, match=expected_error):
+            db.get_leaderboard_templates("does-not-exist")
+        with pytest.raises(leaderboard_db.LeaderboardDoesNotExist, match=expected_error):
+            db.get_leaderboard_gpu_types("does-not-exist")
+        with pytest.raises(leaderboard_db.LeaderboardDoesNotExist, match=expected_error):
+            db.get_leaderboard_submissions("does-not-exist", "A100", "5", 100)
+        with pytest.raises(leaderboard_db.LeaderboardDoesNotExist, match=expected_error):
+            db.get_leaderboard_submission_count("does-not-exist", "A100", "5")
+        assert db.get_leaderboards() == []
+        assert db.get_leaderboard_names() == []
+        assert db.get_submission_by_id(0) is None
+        assert db.get_user_from_id("0") is None
+
+
+def test_nested_enter(database):
+    with database as db_outer:
+        with db_outer as db_inner:
+            assert db_inner.get_leaderboards() == []
+
+
+def test_leaderboard_basics(database, task_directory):
+    """
+    This test creates an empty leaderboard and checks its properties.
+    """
+    from libkernelbot.task import make_task_definition
+
+    definition = make_task_definition(task_directory / "task.yml")
+
+    deadline = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
+
+    with database as db:
+        db.create_leaderboard(
+            name="test-leaderboard",
+            deadline=deadline,
+            definition=definition,
+            creator_id=1,
+            forum_id=5,
+            gpu_types=["A100", "H100"],
+        )
+
+        assert db.get_leaderboard_names() == ["test-leaderboard"]
+        lb = db.get_leaderboard("test-leaderboard")
+
+        assert lb["name"] == "test-leaderboard"
+        assert lb["creator_id"] == 1
+        assert lb["deadline"] == deadline
+        assert lb["description"] == definition.description
+        assert lb["task"] == definition.task
+        assert lb["gpu_types"] == ["A100", "H100"]
+        assert lb["forum_id"] == 5
+        assert lb["id"] == db.get_leaderboard_id("test-leaderboard")
+        assert isinstance(lb["secret_seed"], int)
+
+        assert db.get_leaderboards() == [lb]
+
+        assert db.get_leaderboard_templates("test-leaderboard") == {
+            "Python": "# Python template",
+            "CUDA": "// CUDA template",
+        }
+        assert db.get_leaderboard_gpu_types("test-leaderboard") == ["A100", "H100"]
+        assert db.get_leaderboard_submissions("test-leaderboard", "A100", "5", 100) == []
+        assert db.get_leaderboard_submission_count("test-leaderboard", "A100", "5") == 0
+
+        with pytest.raises(
+            KernelBotError, match="Invalid GPU type 'A99' for leaderboard 'test-leaderboard'"
+        ):
+            assert db.get_leaderboard_submissions("test-leaderboard", "A99", "5", 100) == []
+
+        with pytest.raises(
+            KernelBotError, match="Invalid GPU type 'A99' for leaderboard 'test-leaderboard'"
+        ):
+            assert db.get_leaderboard_submission_count("test-leaderboard", "A99", "5") == 0
+
+
+def test_recreate_leaderboard(database, task_directory):
+    _submit_leaderboard(database, task_directory)
+    with pytest.raises(
+        KernelBotError,
+        match="Error: Tried to create a leaderboard 'submit-leaderboard' that already exists.",
+    ):
+        _submit_leaderboard(database, task_directory)
+
+
+def test_expired_leaderboard(database, task_directory):
+    from libkernelbot.task import make_task_definition
+
+    definition = make_task_definition(task_directory / "task.yml")
+    deadline = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=1)
+
+    _submit_leaderboard(database, task_directory)
+    with database as db:
+        db.create_leaderboard(
+            name="other-leaderboard",
+            deadline=deadline,
+            definition=definition,
+            creator_id=1,
+            forum_id=5,
+            gpu_types=["A100", "H100"],
+        )
+
+        assert len(db.get_leaderboard_names()) == 2
+        assert db.get_leaderboard_names(active_only=True) == ["submit-leaderboard"]
+
+
+def test_leaderboard_submission_basic(database, submit_leaderboard):
+    """
+    This test creates a leaderboard, adds a submission and a few runs, then checks query results.
+    """
+    submit_time = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    # we used to have problems with literal \n in source files, so let's test that here
+    dangerous_code = r"'python string with\nspecial\tcharacters'"
+
+    with database as db:
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 5, dangerous_code, submit_time, user_name="user"
+        )
+
+        # check the raw submission
+        submission = db.get_submission_by_id(sub_id)
+        assert submission["submission_id"] == sub_id
+        assert submission["leaderboard_id"] == db.get_leaderboard_id("submit-leaderboard")
+        assert submission["leaderboard_name"] == "submit-leaderboard"
+        assert submission["file_name"] == "submission.py"
+        assert submission["user_id"] == "5"  # TODO str or int?
+        assert submission["submission_time"] == submit_time
+        assert submission["done"] is False
+        assert submission["code"] == dangerous_code
+        assert submission["runs"] == []
+
+    # add a submission run
+    run_result = sample_run_result()
+    with database as db:
+        end_time = submit_time + datetime.timedelta(seconds=10)
+        db.create_submission_run(
+            sub_id,
+            submit_time,
+            end_time,
+            mode="test",
+            secret=False,
+            runner="A100",
+            score=None,
+            compilation=None,
+            result=run_result,
+            system=sample_system_info(),
+        )
+        # run ends after the contest deadline; this is valid
+        end_time_2 = submit_time + datetime.timedelta(days=1, hours=1)
+        db.create_submission_run(
+            sub_id,
+            submit_time,
+            end_time_2,
+            mode="leaderboard",
+            secret=True,
+            runner="H100",
+            score=5.5,
+            compilation=sample_compile_result(),
+            result=run_result,
+            system=sample_system_info(),
+        )
+
+        expected_meta = {
+            k: getattr(run_result, k)
+            for k in ("stdout", "stderr", "success", "exit_code", "command", "duration")
+        }
+
+        submission = db.get_submission_by_id(sub_id)
+
+        assert len(submission["runs"]) == 2
+        for run in submission["runs"]:
+            if run["mode"] == "test":
+                assert run["start_time"] == submit_time
+                assert run["end_time"] == end_time
+                assert run["secret"] is False
+                assert run["runner"] == "A100"
+                assert run["score"] is None
+                assert run["compilation"] is None
+                assert run["passed"] is True
+                assert run["meta"] == expected_meta
+                assert run["result"] == run_result.result
+                assert run["system"] == dataclasses.asdict(sample_system_info())
+            elif run["mode"] == "leaderboard":
+                assert run["start_time"] == submit_time
+                assert run["end_time"] == end_time_2
+                assert run["secret"] is True
+                assert run["runner"] == "H100"
+                assert run["score"] == 5.5
+                assert run["passed"] is True
+                assert run["compilation"] == dataclasses.asdict(sample_compile_result())
+                assert run["meta"] == expected_meta
+                assert run["result"] == run_result.result
+                assert run["system"] == dataclasses.asdict(sample_system_info())
+
+        db.mark_submission_done(sub_id)
+
+        with pytest.raises(KernelBotError):
+            _create_submission_run(db, sub_id)
+
+
+def test_leaderboard_submission_count(database, submit_leaderboard):
+    """Check submission counting logic"""
+    submit_time = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    # we used to have problems with literal \n in source files, so let's test that here
+    dangerous_code = r"'python string with\nspecial\tcharacters'"
+
+    with database as db:
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 5, dangerous_code, submit_time, user_name="user"
+        )
+        _create_submission_run(db, sub_id, mode="test", secret=False, runner="A100")
+        _create_submission_run(
+            db, sub_id, mode="leaderboard", secret=True, runner="H100", score=5.5
+        )
+        _create_submission_run(
+            db, sub_id, mode="leaderboard", secret=False, runner="A100", score=1.5
+        )
+        submission = db.get_submission_by_id(sub_id)
+
+        assert len(submission["runs"]) == 3
+
+        db.mark_submission_done(sub_id)
+    with database as db:
+        # H100: secret, not counted
+        assert db.get_leaderboard_submission_count("submit-leaderboard", "H100") == 0
+        # A100: only one of the two submissions has a score assigned
+        assert db.get_leaderboard_submission_count("submit-leaderboard", "A100") == 1
+        assert db.get_leaderboard_submission_count("submit-leaderboard", "A100", "5") == 1
+        assert db.get_leaderboard_submission_count("submit-leaderboard", "H100", "6") == 0
+
+
+def test_leaderboard_submission_ranked(database, submit_leaderboard):
+    """Check submission counting logic"""
+    submit_time = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    # we used to have problems with literal \n in source files, so let's test that here
+    dangerous_code = r"'python string with\nspecial\tcharacters'"
+
+    with database as db:
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 5, dangerous_code, submit_time, user_name="user"
+        )
+        _create_submission_run(db, sub_id, mode="leaderboard", runner="A100", score=5.5)
+        db.mark_submission_done(sub_id)
+
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 5, dangerous_code, submit_time, user_name="user"
+        )
+        _create_submission_run(db, sub_id, mode="leaderboard", runner="A100", score=4.5)
+        db.mark_submission_done(sub_id)
+
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 5, dangerous_code, submit_time, user_name="user"
+        )
+        _create_submission_run(db, sub_id, mode="leaderboard", runner="A100", score=5.0)
+        db.mark_submission_done(sub_id)
+
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 6, dangerous_code, submit_time, user_name="user"
+        )
+        _create_submission_run(db, sub_id, mode="leaderboard", runner="A100", score=8.0)
+        db.mark_submission_done(sub_id)
+
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 6, dangerous_code, submit_time, user_name="user"
+        )
+        _create_submission_run(db, sub_id, mode="leaderboard", runner="H100", score=2.0)
+        db.mark_submission_done(sub_id)
+
+    with database as db:
+        ranked_sub = db.get_leaderboard_submissions("submit-leaderboard", "A100", None)
+        from decimal import Decimal
+
+        assert ranked_sub == [
+            {
+                "gpu_type": "A100",
+                "leaderboard_name": "submit-leaderboard",
+                "rank": 1,
+                "submission_id": 2,
+                "submission_name": "submission.py",
+                "submission_score": Decimal("4.5"),
+                "submission_time": submit_time,
+                "user_id": "5",
+                "user_name": "user",
+            },
+            {
+                "gpu_type": "A100",
+                "leaderboard_name": "submit-leaderboard",
+                "rank": 2,
+                "submission_id": 4,
+                "submission_name": "submission.py",
+                "submission_score": Decimal("8.0"),
+                "submission_time": submit_time,
+                "user_id": "6",
+                "user_name": "user",
+            },
+        ]
+
+
+def test_leaderboard_submission_deduplication(database, submit_leaderboard):
+    """validate that identical submission codes are added just once"""
+    with database as db:
+        db.create_submission(
+            "submit-leaderboard",
+            "submission.py",
+            5,
+            "pass",
+            datetime.datetime.now(),
+            user_name="user",
+        )
+        db.create_submission(
+            "submit-leaderboard", "other.py", 6, "pass", datetime.datetime.now(), user_name="other"
+        )
+
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.code_files")
+        assert db.cursor.fetchone()[0] == 1
+
+
+def test_leaderboard_submission_delete(database, submit_leaderboard):
+    with database as db:
+        sub_id = db.create_submission(
+            "submit-leaderboard",
+            "submission.py",
+            5,
+            "pass",
+            datetime.datetime.now(),
+            user_name="user",
+        )
+        other_sub = db.create_submission(
+            "submit-leaderboard",
+            "submission.py",
+            5,
+            "different",
+            datetime.datetime.now(),
+            user_name="user",
+        )
+
+        _create_submission_run(db, sub_id, mode="leaderboard", secret=False, runner="A100", score=5)
+        _create_submission_run(db, sub_id, mode="leaderboard", secret=True, runner="A100", score=5)
+        _create_submission_run(
+            db, other_sub, mode="leaderboard", secret=False, runner="A100", score=5
+        )
+        db.mark_submission_done(sub_id)
+
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.runs")
+        assert db.cursor.fetchone()[0] == 3
+
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.submission")
+        assert db.cursor.fetchone()[0] == 2
+
+        # ok, now delete
+        db.delete_submission(sub_id)
+        assert db.get_submission_by_id(sub_id) is None
+        assert db.get_submission_by_id(other_sub) is not None
+
+        # run and submission are deleted
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.runs")
+        assert db.cursor.fetchone()[0] == 1
+
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.submission")
+        assert db.cursor.fetchone()[0] == 1
+
+        # but the code file remains
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.code_files")
+        assert db.cursor.fetchone()[0] == 2
+
+
+def test_delete_leaderboard(database, submit_leaderboard):
+    with database as db:
+        db.delete_leaderboard("submit-leaderboard")
+        assert db.get_leaderboard_names() == []
+
+
+def test_delete_leaderboard_with_runs(database, submit_leaderboard):
+    with database as db:
+        db.create_submission(
+            "submit-leaderboard",
+            "submission.py",
+            5,
+            "pass",
+            datetime.datetime.now(),
+            user_name="user",
+        )
+
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.templates")
+        assert db.cursor.fetchone()[0] > 0
+
+        with pytest.raises(
+            KernelBotError,
+            match="Could not delete leaderboard `submit-leaderboard` with existing submissions.",
+        ):
+            db.delete_leaderboard("submit-leaderboard")
+
+        # nothing was deleted
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.templates")
+        assert db.cursor.fetchone()[0] > 0
+        assert db.get_leaderboard_names() == ["submit-leaderboard"]
+
+        db.delete_leaderboard("submit-leaderboard", force=True)
+        assert db.get_leaderboard_names() == []
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.submission")
+        assert db.cursor.fetchone()[0] == 0
+
+        db.cursor.execute("SELECT COUNT(*) FROM leaderboard.templates")
+        assert db.cursor.fetchone()[0] == 0
+
+
+def test_leaderboard_update(database, task_directory):
+    from libkernelbot.task import make_task_definition
+
+    definition = make_task_definition(task_directory / "task.yml")
+
+    deadline = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
+    new_deadline = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=2)
+
+    new_def = copy.deepcopy(definition)
+    new_def.description = "new description"
+    new_def.task.test_timeout = 14532
+    new_def.templates["CUDA"] = "// new CUDA template"
+
+    with database as db:
+        # create initial leaderboard
+        db.create_leaderboard(
+            name="test-leaderboard",
+            deadline=deadline,
+            definition=definition,
+            creator_id=1,
+            forum_id=5,
+            gpu_types=["A100", "H100"],
+        )
+
+        # update deadline
+        db.update_leaderboard("test-leaderboard", new_deadline, new_def)
+        updated_lb = db.get_leaderboard("test-leaderboard")
+        assert updated_lb["deadline"] == new_deadline
+        assert updated_lb["description"] == "new description"
+        assert updated_lb["task"] == new_def.task
+
+        assert db.get_leaderboard_templates("test-leaderboard") == {
+            "CUDA": "// new CUDA template",
+            "Python": "# Python template",
+        }
+
+
+def test_generate_stats(database, submit_leaderboard):
+    with database as db:
+        start = datetime.datetime.now(tz=datetime.timezone.utc)
+        sub_id = db.create_submission(
+            "submit-leaderboard", "submission.py", 5, "pass", start, user_name="user"
+        )
+        _create_submission_run(
+            db,
+            sub_id,
+            start=start + datetime.timedelta(seconds=10),
+            end=start + datetime.timedelta(seconds=20),
+            mode="leaderboard",
+            secret=False,
+            runner="A100",
+            score=5,
+        )
+        _create_submission_run(
+            db,
+            sub_id,
+            start=start + datetime.timedelta(seconds=20),
+            end=start + datetime.timedelta(seconds=30),
+            mode="leaderboard",
+            secret=True,
+            runner="A100",
+            score=6,
+        )
+        _create_submission_run(
+            db,
+            sub_id,
+            start=start,
+            end=start + datetime.timedelta(seconds=15),
+            mode="leaderboard",
+            secret=False,
+            runner="A100",
+            score=4,
+        )
+        db.mark_submission_done(sub_id)
+
+        assert db.generate_stats(False) == {
+            "avg_delay.A100": datetime.timedelta(seconds=10),
+            "max_delay.A100": datetime.timedelta(seconds=20),
+            "num_run.A100": 3,
+            "num_submissions": 1,
+            "num_unique_codes": 1,
+            "num_users": 1,
+            "runs_passed.A100": 3,
+            "runs_scored.A100": 3,
+            "runs_secret.A100": 1,
+            "sub_waiting": 0,
+            "total_runtime.A100": datetime.timedelta(seconds=35),
+        }
+
+
+# this is her just to make ruff leave pytest fixtures alone
+__all__ = [task_directory]


### PR DESCRIPTION
This is a heavily modified/updated version of #291 
It is rebased onto the libkernelbot changes, and uses a separate table to store milestone definitions as discussed.

The major design question that I'm not completely sure about is how to handle milestone runs.
In this version of the code, a `milestone_id` column is added to the runs table, and we set a constraint that enforces either submission or milestone id to be set. This is minimally invasive, but I wouldn't call it pretty. Contrary to what I  first thought, though, it doesn't require any changes to existing queries. In order to match runs to leaderboards, we need to join on submission_id, so all milestone runs get filtered out automatically. A good sign for this approach?

Alternatives could be to distinguish at the submission level (as in @PaliC 's original code), or to have two completely separate tables (claude says there is a postgres-specific extension that allows table inheritance, but i'm not really sure of the implications of this).

At this point, the implementation is fully functional, but could use some interface tweaks/improvements:
* API access; should be easy, the main functions are in backend
* display milestones as part of the leaderboard (?)
* automatic celebration message for beating a milestone the first time
* ~update-problems needs to become milestone-aware~ (implemented, but not really tested yet)