### PR TITLE
Adding unit tests

### DIFF
--- a/.github/workflows/runner_ci.yml
+++ b/.github/workflows/runner_ci.yml
@@ -83,3 +83,11 @@ jobs:
     env:
       CUDA_VISIBLE_DEVICES: 0
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync --extra dev
+      - run: uv run pytest unit-tests -v

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -62,6 +62,12 @@ class LeaderboardTask:
     ranking_by: RankCriterion = RankCriterion.LAST
     seed: Optional[int] = None
 
+    def __post_init__(self):
+        if self.lang == Language.Python and not isinstance(self.config, PythonTaskData):
+            raise TypeError("Python language requires PythonTaskData config")
+        if self.lang == Language.CUDA and not isinstance(self.config, CudaTaskData):
+            raise TypeError("CUDA language requires CudaTaskData config")
+
     @classmethod
     def from_dict(cls, data: dict):
         data_ = copy.copy(data)
@@ -147,7 +153,7 @@ def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
 
 
 def build_task_config(
-    task: "LeaderboardTask" = None,
+    task: LeaderboardTask = None,
     submission_content: str = None,
     arch: str = None,
     mode: SubmissionMode = None,

--- a/src/libkernelbot/utils.py
+++ b/src/libkernelbot/utils.py
@@ -60,9 +60,9 @@ class LRUCache:
         self._max_size = max_size
         self._q = []
 
-    def __getitem__(self, key: Any, default: Any = None) -> Any | None:
+    def __getitem__(self, key: Any) -> Any | None:
         if key not in self._cache:
-            return default
+            return None
 
         self._q.remove(key)
         self._q.append(key)
@@ -95,50 +95,51 @@ class LRUCache:
         self._q.clear()
 
 
-def format_time(value: float | str, err: Optional[float | str] = None, scale=None):  # noqa: C901
-    if value is None:
+def format_time(nanoseconds: float | str, err: Optional[float | str] = None):  # noqa: C901
+    if nanoseconds is None:
         logging.warning("Expected a number, got None", stack_info=True)
         return "–"
 
     # really ugly, but works for now
-    value = float(value)
+    nanoseconds = float(nanoseconds)
 
     scale = 1  # nanoseconds
     unit = "ns"
-    if value > 2_000_000:
+    if nanoseconds > 2_000_000:
         scale = 1000_000
         unit = "ms"
-    elif value > 2000:
+    elif nanoseconds > 2000:
         scale = 1000
         unit = "µs"
 
-    value /= scale
+    time_in_unit = nanoseconds / scale
     if err is not None:
         err = float(err)
         err /= scale
-    if value < 1:
+    if time_in_unit < 1:
         if err:
-            return f"{value} ± {err} {unit}"
+            return f"{time_in_unit} ± {err} {unit}"
         else:
-            return f"{value} {unit}"
-    elif value < 10:
+            return f"{time_in_unit} {unit}"
+    elif time_in_unit < 10:
         if err:
-            return f"{value:.2f} ± {err:.3f} {unit}"
+            return f"{time_in_unit:.2f} ± {err:.3f} {unit}"
         else:
-            return f"{value:.2f} {unit}"
-    elif value < 100:
+            return f"{time_in_unit:.2f} {unit}"
+    elif time_in_unit < 100:
         if err:
-            return f"{value:.1f} ± {err:.2f} {unit}"
+            return f"{time_in_unit:.1f} ± {err:.2f} {unit}"
         else:
-            return f"{value:.1f} {unit}"
+            return f"{time_in_unit:.1f} {unit}"
     else:
         if err:
-            return f"{value:.0f} ± {err:.1f} {unit}"
+            return f"{time_in_unit:.0f} ± {err:.1f} {unit}"
         else:
-            return f"{value:.0f} {unit}"
+            return f"{time_in_unit:.0f} {unit}"
 
 
 def limit_length(text: str, maxlen: int):
+    assert maxlen > 6
     if len(text) > maxlen:
         return text[: maxlen - 6] + " [...]"
     else:

--- a/unit-tests/test_report.py
+++ b/unit-tests/test_report.py
@@ -1,0 +1,430 @@
+import base64
+import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from libkernelbot import consts
+from libkernelbot.report import (
+    RunResultReport,
+    _generate_compile_report,
+    _short_fail_reason,
+    generate_report,
+    generate_system_info,
+    make_benchmark_log,
+    make_profile_log,
+    make_short_report,
+    make_test_log,
+)
+from libkernelbot.run_eval import CompileResult, EvalResult, FullResult, RunResult, SystemInfo
+
+
+# define fixtures that create mock results
+@pytest.fixture
+def sample_system_info() -> SystemInfo:
+    return SystemInfo(
+        gpu="NVIDIA RTX 4090", cpu="Intel i9-12900K", platform="Linux-5.15.0", torch="2.0.1+cu118"
+    )
+
+
+@pytest.fixture
+def sample_compile_result() -> CompileResult:
+    return CompileResult(
+        success=True,
+        nvcc_found=True,
+        nvcc_version="11.8",
+        command="nvcc -o test test.cu",
+        exit_code=0,
+        stdout="",
+        stderr="",
+    )
+
+
+@pytest.fixture
+def sample_run_result() -> RunResult:
+    return RunResult(
+        success=True,
+        passed=True,
+        command="./test",
+        exit_code=0,
+        duration=1.5,
+        stdout="All tests passed",
+        stderr="",
+        result={
+            "test-count": "3",
+            "test.0.status": "pass",
+            "test.0.spec": "Test addition",
+            "test.0.message": "Addition works correctly",
+            "test.1.status": "pass",
+            "test.1.spec": "Test multiplication",
+            "test.2.status": "fail",
+            "test.2.spec": "Test division",
+            "test.2.error": "Division by zero",
+        },
+    )
+
+
+@pytest.fixture
+def sample_eval_result(
+    sample_compile_result: CompileResult, sample_run_result: RunResult
+) -> EvalResult:
+    return EvalResult(
+        start=datetime.datetime.now() - datetime.timedelta(minutes=5),
+        end=datetime.datetime.now(),
+        compilation=sample_compile_result,
+        run=sample_run_result,
+    )
+
+
+@pytest.fixture
+def sample_full_result(
+    sample_system_info: SystemInfo, sample_eval_result: EvalResult
+) -> FullResult:
+    return FullResult(
+        success=True, error="", system=sample_system_info, runs={"test": sample_eval_result}
+    )
+
+
+################################################
+#       Compilation report tests
+################################################
+
+
+def test_generate_compile_report_nvcc_not_found(sample_compile_result: CompileResult):
+    sample_compile_result.success = False
+    sample_compile_result.nvcc_found = False
+    sample_compile_result.command = ""
+    sample_compile_result.exit_code = 127
+    sample_compile_result.stderr = "nvcc: command not found"
+    sample_compile_result.stdout = ""
+
+    reporter = RunResultReport()
+    _generate_compile_report(reporter, sample_compile_result)
+
+    assert len(reporter.data) == 1
+    assert hasattr(reporter.data[0], "text")
+
+    text = reporter.data[0].text
+    assert "NVCC could not be found" in text
+    assert "bug in the runner configuration" in text
+    assert "notify the server admins" in text
+
+
+def test_generate_compile_report_with_errors(sample_compile_result: CompileResult):
+    sample_compile_result.success = False
+    sample_compile_result.nvcc_found = True
+    sample_compile_result.command = "nvcc -o test test.cu -arch=sm_75"
+    sample_compile_result.exit_code = 1
+    sample_compile_result.stderr = 'test.cu(15): error: identifier "invalid_function" is undefined'
+    sample_compile_result.stdout = "warning: deprecated feature used"
+
+    reporter = RunResultReport()
+    _generate_compile_report(reporter, sample_compile_result)
+
+    # Should have compilation text + stderr log + stdout log
+    assert len(reporter.data) == 3
+
+    # Check compilation failure message
+    assert hasattr(reporter.data[0], "text")
+    text = reporter.data[0].text
+    assert "Compilation failed" in text
+    assert "nvcc -o test test.cu -arch=sm_75" in text
+    assert "exited with code **1**" in text
+
+    # Check stderr and stdout logs
+    assert hasattr(reporter.data[1], "header")
+    assert reporter.data[1].header == "Compiler stderr"
+    assert 'identifier "invalid_function" is undefined' in reporter.data[1].content
+
+    assert hasattr(reporter.data[2], "header")
+    assert reporter.data[2].header == "Compiler stdout"
+    assert "warning: deprecated feature used" in reporter.data[2].content
+
+
+def test_generate_compile_report_no_stdout(sample_compile_result: CompileResult):
+    sample_compile_result.success = False
+    sample_compile_result.nvcc_found = True
+    sample_compile_result.command = "nvcc -o test test.cu"
+    sample_compile_result.exit_code = 1
+    sample_compile_result.stderr = "compilation error"
+    sample_compile_result.stdout = ""
+
+    reporter = RunResultReport()
+    _generate_compile_report(reporter, sample_compile_result)
+
+    # Should have compilation text + stderr log (no stdout log)
+    assert len(reporter.data) == 2
+
+    assert hasattr(reporter.data[0], "text")
+    assert "Compilation failed" in reporter.data[0].text
+
+    assert hasattr(reporter.data[1], "header")
+    assert reporter.data[1].header == "Compiler stderr"
+    assert "compilation error" in reporter.data[1].content
+
+
+################################################
+#       Short report tests
+################################################
+
+
+def test_short_fail_reason(sample_run_result: RunResult):
+    sample_run_result.exit_code = consts.ExitCode.TIMEOUT_EXPIRED
+    assert _short_fail_reason(sample_run_result) == " (timeout)"
+
+    sample_run_result.exit_code = consts.ExitCode.CUDA_FAIL
+    assert _short_fail_reason(sample_run_result) == " (cuda api error)"
+
+    # VALIDATE_FAIL means unit tests failed, which will be reported differently
+    sample_run_result.exit_code = consts.ExitCode.VALIDATE_FAIL
+    assert _short_fail_reason(sample_run_result) == ""
+
+    sample_run_result.exit_code = 42
+    assert _short_fail_reason(sample_run_result) == " (internal error 42)"
+
+
+def test_make_short_report_compilation_failed(sample_eval_result: EvalResult):
+    sample_eval_result.compilation.success = False
+    runs = {"test": sample_eval_result}
+
+    result = make_short_report(runs)
+    assert result == ["❌ Compilation failed"]
+
+
+def test_make_short_report_full_success(sample_compile_result: CompileResult):
+    runs = {}
+    for run_type in ["test", "benchmark", "profile", "leaderboard"]:
+        runs[run_type] = EvalResult(
+            start=datetime.datetime.now() - datetime.timedelta(minutes=5),
+            end=datetime.datetime.now(),
+            compilation=sample_compile_result,
+            run=RunResult(
+                success=True,
+                passed=True,
+                command="./test",
+                exit_code=0,
+                duration=1.5,
+                stdout="",
+                stderr="",
+                result={},
+            ),
+        )
+
+    result = make_short_report(runs, full=True)
+    expected = [
+        "✅ Compilation successful",
+        "✅ Testing successful",
+        "✅ Benchmarking successful",
+        "✅ Profiling successful",
+        "✅ Leaderboard run successful",
+    ]
+    assert result == expected
+
+
+def test_make_short_report_missing_components(sample_eval_result: EvalResult):
+    runs = {"test": sample_eval_result}
+
+    result = make_short_report(runs, full=True)
+    expected = [
+        "✅ Compilation successful",
+        "✅ Testing successful",
+        "❌ Benchmarks missing",
+        "❌ Leaderboard missing",
+    ]
+    assert result == expected
+
+
+################################################
+#    Test, Benchmark, Profile reporting
+################################################
+
+
+def test_make_test_log(sample_run_result: RunResult):
+    log = make_test_log(sample_run_result)
+    expected_lines = [
+        "✅ Test addition",
+        "> Addition works correctly",
+        "✅ Test multiplication",
+        "❌ Test division",
+        "> Division by zero",
+    ]
+    assert log == "\n".join(expected_lines)
+
+
+def test_make_test_log_no_tests():
+    run = Mock()
+    run.result = {}
+
+    log = make_test_log(run)
+    assert log == "❗ Could not find any test cases"
+
+
+def test_make_benchmark_log():
+    run = Mock()
+    run.result = {
+        "benchmark-count": "2",
+        "benchmark.0.status": "pass",
+        "benchmark.0.spec": "Matrix multiplication",
+        "benchmark.0.mean": "1.5",
+        "benchmark.0.err": "0.1",
+        "benchmark.0.best": "1.3",
+        "benchmark.0.worst": "1.8",
+        "benchmark.1.status": "fail",
+        "benchmark.1.spec": "Vector addition",
+        "benchmark.1.error": "Timeout occurred",
+    }
+
+    log = make_benchmark_log(run)
+
+    assert "Matrix multiplication" in log
+    assert "Vector addition" in log
+    assert "❌ Vector addition failed testing:" in log
+    assert "Timeout occurred" in log
+
+
+def test_make_benchmark_log_no_benchmarks():
+    run = Mock()
+    run.result = {"benchmark-count": "0"}
+
+    log = make_benchmark_log(run)
+    assert log == "❗ Could not find any benchmarks"
+
+
+def test_make_profile_log():
+    profile_data = "Profile line 1\nProfile line 2"
+    encoded_data = base64.b64encode(profile_data.encode("utf-8"), b"+*").decode("utf-8")
+
+    run = Mock()
+    run.result = {
+        "benchmark-count": "1",
+        "benchmark.0.spec": "Matrix multiplication profile",
+        "benchmark.0.report": encoded_data,
+    }
+
+    log = make_profile_log(run)
+
+    assert "Matrix multiplication profile" in log
+    assert "  Profile line 1" in log
+    assert "  Profile line 2" in log
+
+
+def test_make_profile_log_no_data():
+    run = Mock()
+    run.result = {"benchmark-count": "0"}
+
+    log = make_profile_log(run)
+    assert log == "❗ Could not find any profiling data"
+
+
+def test_generate_system_info(sample_system_info: SystemInfo):
+    info = generate_system_info(sample_system_info)
+
+    expected_parts = ["NVIDIA RTX 4090", "Intel i9-12900K", "Linux-5.15.0", "2.0.1+cu118"]
+
+    for part in expected_parts:
+        assert part in info
+
+
+################################################
+#    Full report
+################################################
+
+
+def test_generate_report_successful_test(sample_full_result: FullResult):
+    report = generate_report(sample_full_result)
+
+    assert len(report.data) >= 2
+    assert any("NVIDIA RTX 4090" in item.text for item in report.data if hasattr(item, "text"))
+
+
+def test_generate_report_compilation_failure(sample_full_result: FullResult):
+    sample_full_result.runs["test"].compilation.success = False
+
+    report = generate_report(sample_full_result)
+
+    # Should return early with compilation failure using _generate_compile_report
+    text_items = [item.text for item in report.data if hasattr(item, "text")]
+    assert any("Compilation failed" in text for text in text_items)
+
+
+def test_generate_report_runtime_crash(sample_full_result: FullResult):
+    sample_full_result.runs["test"].run = RunResult(
+        success=False,
+        passed=False,
+        command="./test_kernel",
+        exit_code=consts.ExitCode.CUDA_FAIL,
+        duration=0.5,
+        stdout="",
+        stderr="CUDA error: invalid device function",
+        result={},
+    )
+
+    report = generate_report(sample_full_result)
+
+    # Should have system info + crash message + stderr log
+    assert len(report.data) == 3
+
+    text_items = [item.text for item in report.data if hasattr(item, "text")]
+    crash_text = next(text for text in text_items if "Running failed" in text)
+
+    assert "./test_kernel" in crash_text
+    assert f"exited with error code **{consts.ExitCode.CUDA_FAIL}**" in crash_text
+    assert "after 0.50 seconds" in crash_text
+
+    # Check stderr log
+    log_items = [item for item in report.data if hasattr(item, "header")]
+    stderr_log = next(item for item in log_items if item.header == "Program stderr")
+    assert "CUDA error: invalid device function" in stderr_log.content
+
+
+def test_generate_report_test_failure(sample_full_result: FullResult):
+    sample_full_result.runs["test"].run = RunResult(
+        success=True,
+        passed=False,
+        command="python eval.py test",
+        exit_code=consts.ExitCode.VALIDATE_FAIL,
+        duration=2.1,
+        stdout="Running tests...",
+        stderr="",
+        result={
+            "test-count": "2",
+            "test.0.status": "pass",
+            "test.0.spec": "Basic functionality",
+            "test.1.status": "fail",
+            "test.1.spec": "Edge case handling",
+            "test.1.error": "Expected [1, 2, 3] but got [1, 2, 0]",
+        },
+    )
+
+    report = generate_report(sample_full_result)
+
+    # Should have system info + test failure text + test log + stdout log
+    assert len(report.data) == 4
+
+    text_items = [item.text for item in report.data if hasattr(item, "text")]
+    test_text = next(text for text in text_items if "Testing failed" in text)
+
+    assert "python eval.py test" in test_text
+    assert "ran successfully in 2.10 seconds" in test_text
+    assert "did not pass all tests" in test_text
+
+    # Check test log contains failure details
+    log_items = [item for item in report.data if hasattr(item, "header")]
+    test_log = next(item for item in log_items if item.header == "Test log")
+    assert "✅ Basic functionality" in test_log.content
+    assert "❌ Edge case handling" in test_log.content
+    assert "Expected [1, 2, 3] but got [1, 2, 0]" in test_log.content
+
+
+def test_run_result_report():
+    reporter = RunResultReport()
+
+    reporter.add_text("Test message")
+    reporter.add_log("Test Header", "Test log content")
+
+    assert len(reporter.data) == 2
+    assert hasattr(reporter.data[0], "text")
+    assert reporter.data[0].text == "Test message"
+    assert hasattr(reporter.data[1], "header")
+    assert reporter.data[1].header == "Test Header"
+    assert reporter.data[1].content == "Test log content"

--- a/unit-tests/test_submission.py
+++ b/unit-tests/test_submission.py
@@ -1,0 +1,331 @@
+import datetime
+from unittest import mock
+
+import pytest
+
+from libkernelbot import submission
+from libkernelbot.consts import RankCriterion
+from libkernelbot.db_types import LeaderboardItem
+from libkernelbot.utils import KernelBotError
+
+
+@pytest.fixture
+def mock_backend():
+    """Create a mock backend with database context for testing."""
+    backend = mock.Mock()
+    backend.accepts_jobs = True
+
+    # Mock database context manager
+    db_context = mock.Mock()
+    backend.db = db_context
+    db_context.__enter__ = mock.Mock(return_value=db_context)
+    db_context.__exit__ = mock.Mock(return_value=None)
+
+    # Default mock responses
+    mock_task = mock.Mock()
+    db_context.get_leaderboard.return_value = {
+        "task": mock_task,
+        "secret_seed": 12345,
+        "deadline": datetime.datetime.now() + datetime.timedelta(days=1),
+        "name": "test_board",
+    }
+    db_context.get_leaderboard_gpu_types.return_value = ["A100", "V100"]
+
+    return backend
+
+
+def test_check_deadline():
+    # Test valid deadline (future)
+    future_deadline: LeaderboardItem = {
+        "deadline": datetime.datetime.now() + datetime.timedelta(days=1),
+        "name": "test",
+    }
+    submission.check_deadline(future_deadline)  # Should not raise
+
+    # Test expired deadline
+    past_deadline: LeaderboardItem = {
+        "deadline": datetime.datetime.now() - datetime.timedelta(days=1),
+        "name": "test",
+    }
+
+    with pytest.raises(
+        KernelBotError, match=r"The deadline to submit to test has passed\.\nIt was.*and today is.*"
+    ):
+        submission.check_deadline(past_deadline)
+
+
+def test_get_avail_gpus(mock_backend):
+    db = mock_backend.db
+    # Test with available GPUs
+    result = submission.get_avail_gpus("test_board", db)
+    assert result == ["A100", "V100"]
+
+    # Test with no available GPUs
+    db.get_leaderboard_gpu_types.return_value = []
+    with pytest.raises(KernelBotError, match="No available GPUs"):
+        submission.get_avail_gpus("test_board", db)
+
+
+def test_get_popcorn_directives_valid():
+    # Python comments with GPU and leaderboard directives
+    code_py = """#!POPCORN gpu A100 V100
+#!POPCORN leaderboard my_board
+print("hello")"""
+    result = submission._get_popcorn_directives(code_py)
+    assert result == {"gpus": ["A100", "V100"], "leaderboard": "my_board"}
+
+    # C++ comments
+    code_cpp = """//!POPCORN gpu L4
+//!POPCORN leaderboard cpp_board
+int main() {}"""
+    result = submission._get_popcorn_directives(code_cpp)
+    assert result == {"gpus": ["L4"], "leaderboard": "cpp_board"}
+
+    # no directives
+    code_empty = """print("no directives")"""
+    result = submission._get_popcorn_directives(code_empty)
+    assert result == {"gpus": None, "leaderboard": None}
+
+    # directives only in the first comment block
+    code_mixed = """#!POPCORN leaderboard valid_board
+print("code")
+#!POPCORN gpu a100"""
+    result = submission._get_popcorn_directives(code_mixed)
+    assert result == {"gpus": None, "leaderboard": "valid_board"}
+
+    # Only whitespace
+    result = submission._get_popcorn_directives("   \n\t  \n")
+    assert result == {"gpus": None, "leaderboard": None}
+
+    # Case sensitivity
+    code_case = """#!POPCORN GPUs a100 v100
+#!POPCORN LEADERBOARD My_Board"""
+    result = submission._get_popcorn_directives(code_case)
+    # Assuming the function is case-insensitive for keywords but preserves case for values
+    assert result == {"gpus": ["a100", "v100"], "leaderboard": "My_Board"}
+
+    # Extra whitespace
+    code_whitespace = """#!POPCORN  gpu   A100    V100  
+#!POPCORN   leaderboard    my_board   """  # noqa: W291
+    result = submission._get_popcorn_directives(code_whitespace)
+    assert result == {"gpus": ["A100", "V100"], "leaderboard": "my_board"}
+
+    # Single GPU
+    code_single_gpu = """#!POPCORN gpu H100"""
+    result = submission._get_popcorn_directives(code_single_gpu)
+    assert result == {"gpus": ["H100"], "leaderboard": None}
+
+
+def test_get_popcorn_directives_invalid():
+    # Empty GPU list
+    with pytest.raises(KernelBotError, match="!POPCORN directive missing argument: #!POPCORN gpu"):
+        submission._get_popcorn_directives("#!POPCORN gpu")
+
+    # Empty leaderboard but valid GPU
+    code_empty_leaderboard = """#!POPCORN gpu A100
+#!POPCORN leaderboard"""
+    with pytest.raises(
+        KernelBotError, match="!POPCORN directive missing argument: #!POPCORN leaderboard"
+    ):
+        submission._get_popcorn_directives(code_empty_leaderboard)
+
+    # Invalid directive
+    with pytest.raises(KernelBotError, match="Invalid !POPCORN directive: invalid_directive"):
+        submission._get_popcorn_directives("#!POPCORN invalid_directive value")
+
+    # Multiple leaderboard directives (last one wins or first one wins?)
+    code_multiple_leaderboard = """#!POPCORN leaderboard first_board
+#!POPCORN leaderboard second_board"""
+    with pytest.raises(
+        KernelBotError, match="Found multiple values for !POPCORN directive leaderboard"
+    ):
+        submission._get_popcorn_directives(code_multiple_leaderboard)
+
+
+def test_handle_popcorn_directives():
+    req = submission.SubmissionRequest(
+        code="#!POPCORN leaderboard test_board",
+        file_name="test.py",
+        user_id=1,
+        user_name="user",
+        gpus=None,
+        leaderboard=None,
+    )
+
+    # Directive sets leaderboard
+    result = submission.handle_popcorn_directives(req)
+    assert result.leaderboard == "test_board"
+
+    # Consistent double-specification is fine
+    req.leaderboard = "test_board"
+    result = submission.handle_popcorn_directives(req)
+    assert result.leaderboard == "test_board"
+
+    # But inconsistent values are rejected
+    req.leaderboard = "different_board"
+    expected_error = (
+        "Leaderboard name `different_board` specified in the "
+        "command doesn't match the one in the submission script header `test_board`."
+    )
+    with pytest.raises(KernelBotError, match=expected_error):
+        submission.handle_popcorn_directives(req)
+
+    # Test missing leaderboard
+    req.code = "print('no directive')"
+    req.leaderboard = None
+    with pytest.raises(KernelBotError, match="Missing leaderboard name"):
+        submission.handle_popcorn_directives(req)
+
+
+def test_prepare_submission_basic(mock_backend):
+    req = submission.SubmissionRequest(
+        code="#!POPCORN leaderboard test_board\nprint('hello world')",
+        file_name="test.py",
+        user_id=1,
+        user_name="test_user",
+        gpus=None,
+        leaderboard=None,
+    )
+
+    result = submission.prepare_submission(req, mock_backend)
+
+    assert isinstance(result, submission.ProcessedSubmissionRequest)
+    assert result.leaderboard == "test_board"
+    assert result.secret_seed == 12345
+    assert result.gpus is None
+    assert result.user_id == req.user_id
+    assert result.user_name == req.user_name
+    assert result.file_name == req.file_name
+    assert result.code == req.code
+    assert result.task == mock_backend.db.get_leaderboard()["task"]
+    assert result.task_gpus == ["A100", "V100"]
+
+
+def test_prepare_submission_explicit(mock_backend):
+    req = submission.SubmissionRequest(
+        code="print('hello world')",
+        file_name="test.cu",
+        user_id=2,
+        user_name="test_user2",
+        gpus=["A100"],
+        leaderboard="test_board",
+    )
+
+    result = submission.prepare_submission(req, mock_backend)
+
+    assert result.leaderboard == "test_board"
+    assert result.gpus == ["A100"]
+    assert result.file_name == "test.cu"
+    assert result.task_gpus == ["A100", "V100"]
+
+
+def test_prepare_submission_single_gpu_auto_assign(mock_backend):
+    mock_backend.db.get_leaderboard_gpu_types.return_value = ["H100"]
+
+    req = submission.SubmissionRequest(
+        code="#!POPCORN leaderboard test_board\nint main() { return 0; }",
+        file_name="test.cpp",
+        user_id=3,
+        user_name="test_user3",
+        gpus=None,
+        leaderboard=None,
+    )
+
+    result = submission.prepare_submission(req, mock_backend)
+
+    assert result.gpus == ["H100"]
+    assert result.task_gpus == ["H100"]
+
+
+def test_prepare_submission_gpu_from_popcorn(mock_backend):
+    # Customize the mock for multiple GPU scenario
+    mock_backend.db.get_leaderboard_gpu_types.return_value = ["A100", "V100", "H100"]
+
+    req = submission.SubmissionRequest(
+        code="#!POPCORN gpu V100 H100\n#!POPCORN leaderboard test_board\nprint('test')",
+        file_name="test.py",
+        user_id=4,
+        user_name="test_user4",
+        gpus=None,
+        leaderboard=None,
+    )
+
+    result = submission.prepare_submission(req, mock_backend)
+
+    assert result.gpus == ["V100", "H100"]
+    assert result.leaderboard == "test_board"
+
+
+def test_prepare_submission_checks(mock_backend):
+    req = submission.SubmissionRequest(
+        code="#!POPCORN leaderboard test_board",
+        file_name="test.py",
+        user_id=1,
+        user_name="user",
+        gpus=None,
+        leaderboard=None,
+    )
+
+    # backend not accepting jobs
+    mock_backend.accepts_jobs = False
+    with pytest.raises(KernelBotError, match="not accepting"):
+        submission.prepare_submission(req, mock_backend)
+
+    # profane filename
+    mock_backend.accepts_jobs = True
+    req.file_name = "this_file_can_fuck_right_off.py"
+    with pytest.raises(KernelBotError, match="Please provide a non-rude filename"):
+        submission.prepare_submission(req, mock_backend)
+
+    # invalid file extension
+    req.file_name = "test.txt"
+    with pytest.raises(
+        KernelBotError, match=r"Please provide a Python \(.py\) or CUDA \(.cu / .cuh / .cpp\) file"
+    ):
+        submission.prepare_submission(req, mock_backend)
+
+
+def test_compute_score():
+    mock_task = mock.Mock()
+    mock_result = mock.Mock()
+
+    # Test LAST ranking with single benchmark
+    mock_task.ranking_by = RankCriterion.LAST
+    mock_result.runs = {
+        "leaderboard": mock.Mock(
+            run=mock.Mock(
+                result={
+                    "benchmark-count": "1",
+                    "benchmark.0.mean": "2000000000",  # 2 seconds in nanoseconds
+                }
+            )
+        )
+    }
+    score = submission.compute_score(mock_result, mock_task, 1)
+    assert score == 2.0
+
+    # Test MEAN ranking with multiple benchmarks
+    mock_task.ranking_by = RankCriterion.MEAN
+    mock_result.runs["leaderboard"].run.result = {
+        "benchmark-count": "2",
+        "benchmark.0.mean": "1000000000",  # 1 second
+        "benchmark.1.mean": "3000000000",  # 3 seconds
+    }
+    score = submission.compute_score(mock_result, mock_task, 1)
+    assert score == 2.0  # (1 + 3) / 2
+
+    # Test GEOM ranking with multiple benchmarks
+    mock_task.ranking_by = RankCriterion.GEOM
+    mock_result.runs["leaderboard"].run.result = {
+        "benchmark-count": "2",
+        "benchmark.0.mean": "4000000000",  # 4 seconds
+        "benchmark.1.mean": "9000000000",  # 9 seconds
+    }
+    score = submission.compute_score(mock_result, mock_task, 1)
+    assert score == 6.0  # sqrt(4 * 9)
+
+    # Test LAST with multiple benchmarks (should raise error)
+    mock_task.ranking_by = RankCriterion.LAST
+    mock_result.runs["leaderboard"].run.result["benchmark-count"] = "2"
+    with pytest.raises(KernelBotError, match="exactly one benchmark"):
+        submission.compute_score(mock_result, mock_task, 1)

--- a/unit-tests/test_task.py
+++ b/unit-tests/test_task.py
@@ -1,0 +1,219 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from libkernelbot.consts import SubmissionMode
+from libkernelbot.task import (
+    CudaTaskData,
+    Language,
+    LeaderboardDefinition,
+    LeaderboardTask,
+    PythonTaskData,
+    RankCriterion,
+    build_task_config,
+    make_task_definition,
+)
+
+
+@pytest.fixture()
+def leaderboard_task():
+    return LeaderboardTask(
+        lang=Language.Python,
+        files={"test.py": "code", "main.py": "@SUBMISSION@"},
+        config=PythonTaskData(main="main.py"),
+        ranking_by=RankCriterion.GEOM,
+        test_timeout=120,
+        tests=[{"input_size": 1000, "dtype": "float32"}, {"input_size": 5000, "dtype": "float16"}],
+        benchmarks=[
+            {"input_size": 10000, "dtype": "float32"},
+            {"input_size": 50000, "dtype": "float16"},
+        ],
+    )
+
+
+def test_from_dict_python_task():
+    """Test creating LeaderboardTask from dict with Python config"""
+    data = {
+        "lang": "py",
+        "files": {"main.py": "print('hello')"},
+        "config": {"main": "main"},
+        "tests": [{"input": "test"}],
+        "ranking_by": "last",
+    }
+
+    old_value = copy.deepcopy(data)
+    task = LeaderboardTask.from_dict(data)
+
+    assert task.lang.value == "py"
+    assert task.files == {"main.py": "print('hello')"}
+    assert isinstance(task.config, PythonTaskData)
+    assert task.ranking_by == RankCriterion.LAST
+    assert task.tests == [{"input": "test"}]
+
+    # check that from_dict does not modify data
+    assert data == old_value
+
+
+def test_from_dict_cuda_task():
+    """Test creating LeaderboardTask from dict with CUDA config"""
+    """Test creating LeaderboardTask from dict with CUDA config"""
+    data = {
+        "lang": "cu",
+        "files": {"kernel.cu": "__global__ void test(){}"},
+        "config": {
+            "sources": ["kernel.cu"],
+            "include_dirs": ["/usr/include"],
+            "defines": {"DEBUG": "1"},
+            "compile_flags": ["-O2"],
+        },
+    }
+
+    old_value = copy.deepcopy(data)
+    task = LeaderboardTask.from_dict(data)
+
+    assert task.lang == Language.CUDA
+    assert isinstance(task.config, CudaTaskData)
+    assert task.config.sources == ["kernel.cu"]
+    assert task.config.include_dirs == ["/usr/include"]
+    assert task.config.defines == {"DEBUG": "1"}
+    assert task.config.compile_flags == ["-O2"]
+    assert task.ranking_by == RankCriterion.LAST
+
+    # check that from_dict does not modify data
+    assert data == old_value
+
+
+def test_type_mismatch():
+    """Claim CUDA but supply python"""
+    with pytest.raises(TypeError):
+        _ = LeaderboardTask(
+            lang=Language.CUDA, files={"test.py": "code"}, config=PythonTaskData(main="main")
+        )
+
+
+def test_to_dict(leaderboard_task):
+    """Test converting LeaderboardTask to dict"""
+    result = leaderboard_task.to_dict()
+
+    assert result["lang"] == Language.Python.value
+    assert result["files"] == {
+        "test.py": "code",
+        "main.py": "@SUBMISSION@",
+    }
+    assert result["ranking_by"] == RankCriterion.GEOM.value
+    assert result["test_timeout"] == 120
+    assert result["tests"] == [
+        {"input_size": 1000, "dtype": "float32"},
+        {"input_size": 5000, "dtype": "float16"},
+    ]
+    assert result["benchmarks"] == [
+        {"input_size": 10000, "dtype": "float32"},
+        {"input_size": 50000, "dtype": "float16"},
+    ]
+
+
+def test_serialization_roundtrip(leaderboard_task):
+    """Test to_str and from_str work together"""
+    json_str = leaderboard_task.to_str()
+    reconstructed = LeaderboardTask.from_str(json_str)
+
+    assert reconstructed == leaderboard_task
+
+
+def test_build_task_config_python(leaderboard_task):
+    """Test build_task_config with Python task and submission content."""
+    submission_content = "print('Hello World')"
+    arch = "sm_80"
+    mode = SubmissionMode.BENCHMARK
+
+    result = build_task_config(
+        task=leaderboard_task, submission_content=submission_content, arch=arch, mode=mode
+    )
+
+    # make sure result is serializable
+    json.dumps(result)
+
+    expected = {
+        "main": "main.py",
+        "sources": {"test.py": "code", "main.py": "print('Hello World')"},
+        "lang": "py",
+        "arch": "sm_80",
+        "benchmarks": [
+            {"input_size": 10000, "dtype": "float32"},
+            {"input_size": 50000, "dtype": "float16"},
+        ],
+        "tests": [
+            {"input_size": 1000, "dtype": "float32"},
+            {"input_size": 5000, "dtype": "float16"},
+        ],
+        "mode": mode.value,
+        "test_timeout": 120,
+        "benchmark_timeout": 180,
+        "ranked_timeout": 180,
+        "ranking_by": "geom",
+        "seed": None,
+    }
+
+    assert result == expected
+
+
+TASK_YAML = """
+lang: py
+description: "Test task description"
+ranking_by: geom
+test_timeout: 120
+files:
+  - name: "kernel.py"
+    source: "kernel.py"
+  - name: "submission.py"
+    source: "@SUBMISSION@"
+config:
+  main: "kernel.py"
+tests:
+  - input_size: 1000
+    dtype: "float32"
+benchmarks:
+  - input_size: 10000
+    dtype: "float32"
+templates:
+  Python: "template.py"
+  CUDA: "template.cu"
+"""
+
+
+@pytest.fixture
+def task_directory(tmp_path):
+    """Create a temporary directory structure for task definition testing"""
+    # Create source files
+    Path.write_text(tmp_path / "kernel.py", "def kernel(): pass")
+    Path.write_text(tmp_path / "template.py", "# Python template")
+    Path.write_text(tmp_path / "template.cu", "// CUDA template")
+
+    # Create task.yml
+    Path.write_text(tmp_path / "task.yml", TASK_YAML)
+    return tmp_path
+
+
+def test_make_task_definition(task_directory):
+    """Test make_task_definition with a complete YAML structure"""
+
+    # Test the function
+    result = make_task_definition(task_directory / "task.yml")
+
+    # Verify LeaderboardDefinition structure
+    assert isinstance(result, LeaderboardDefinition)
+    assert result.description == "Test task description"
+    assert result.templates == {"Python": "# Python template", "CUDA": "// CUDA template"}
+
+    # Verify the task
+    task = result.task
+    assert task.lang == Language.Python
+    assert task.files == {"kernel.py": "def kernel(): pass", "submission.py": "@SUBMISSION@"}
+    assert task.ranking_by == RankCriterion.GEOM
+    assert task.test_timeout == 120
+    assert task.tests == [{"input_size": 1000, "dtype": "float32"}]
+    assert task.benchmarks == [{"input_size": 10000, "dtype": "float32"}]
+    assert isinstance(task.config, PythonTaskData)
+    assert task.config.main == "kernel.py"

--- a/unit-tests/test_utils.py
+++ b/unit-tests/test_utils.py
@@ -1,0 +1,83 @@
+from libkernelbot import utils
+
+
+def test_format_time():
+    """Test time-formatting based on examples"""
+    # without error
+    assert utils.format_time(1) == "1.00 ns"
+    assert utils.format_time("1") == "1.00 ns"
+    assert utils.format_time(15.7) == "15.7 ns"
+    assert utils.format_time(1012) == "1012 ns"
+    assert utils.format_time(1518.4) == "1518 ns"
+
+    assert utils.format_time(2152) == "2.15 µs"
+    assert utils.format_time(51242) == "51.2 µs"
+    assert utils.format_time(8_428_212) == "8.43 ms"
+
+    # with error
+    assert utils.format_time(1, "0.01") == "1.00 ± 0.010 ns"
+    assert utils.format_time(52, 5.85) == "52.0 ± 5.85 ns"
+    # TODO should we enforce that nonzero error never rounds to zero?
+    assert utils.format_time(2152, 0.1) == "2.15 ± 0.000 µs"
+    assert utils.format_time(3_754_123, 24_432) == "3.75 ± 0.024 ms"
+
+    assert utils.format_time(None) == "–"
+
+
+def test_limit_length():
+    """Test utils.limit_length"""
+    assert utils.limit_length("This is long text", 17) == "This is long text"
+    assert utils.limit_length("This is long text", 10) == "This [...]"
+
+
+def test_lru_basic_operations():
+    """Test basic set, get, contains, and len operations"""
+    cache = utils.LRUCache(3)
+
+    # Test initial state
+    assert len(cache) == 0
+    assert "key" not in cache
+    assert cache["nonexistent"] is None
+
+    # Test set and get
+    cache["key"] = "value"
+    assert cache["key"] == "value"
+    assert "key" in cache
+    assert len(cache) == 1
+
+
+def test_lru_eviction_and_ordering():
+    """Test LRU eviction and queue ordering"""
+    cache = utils.LRUCache(2)
+
+    # Fill cache
+    cache["a"] = 1
+    cache["b"] = 2
+    assert cache._q == ["a", "b"]
+
+    # Access 'a' to move it to end
+    _ = cache["a"]
+    assert cache._q == ["b", "a"]
+
+    # Add new item, should evict 'b'
+    cache["c"] = 3
+    assert "b" not in cache
+    assert cache._q == ["a", "c"]
+
+    # Writing also reorders
+    cache["c"] = 5
+    cache["a"] = 4
+    assert cache._q == ["c", "a"]
+
+
+def test_lru_invalidate():
+    """Test invalidate clears cache and queue"""
+    cache = utils.LRUCache(3)
+    cache["a"] = 1
+    cache["b"] = 2
+
+    cache.invalidate()
+
+    assert len(cache) == 0
+    assert "a" not in cache
+    assert cache._q == []


### PR DESCRIPTION
This PR adds a bunch of unit tests for libkernelbot. While doing so, slight improvements (error checking) were made to submission.py.
This doesn't cover all the files in libkernelbot, but `consts.py` and `db_types.py` just define dataclasses/enums so there's not much to test there, and `leaderboard_db.py`, `backend.py` how much **unit** testing we can actually do there (i.e., is it even worth trying to mock the db, or should we just aim for some integration tests that actually start the postgres service and populate a real database?)

The tests for report.py are mostly claude generated, with some strong opinionated guidance to make them somewhat manageable.