### PR TITLE
Multi-GPU

### DIFF
--- a/examples/eval.py
+++ b/examples/eval.py
@@ -197,7 +197,8 @@ def run_multi_gpu_test(pool: multiprocessing.Pool, test: TestCase, world_size: i
                 args=(test, i),
             )
         )
-    rets = [el.get() for el in rets]
+    # 60 seconds should be more than enough, we want tests to be fast
+    rets = [el.get(60) for el in rets]
 
     correct = all(ret[0] for ret in rets)
     error_messages = str.join("\n", [f"rank {rank} - {ret[1]}" for rank, ret in enumerate(rets) if not ret[0]])
@@ -422,7 +423,9 @@ def run_multi_gpu_benchmark(pool: multiprocessing.Pool, test: TestCase, recheck:
                 args=(test, i, recheck, max_repeats, max_time_ns),
             )
         )
-    rets = [el.get() for el in rets]
+
+    # 120 seconds for benchmarking + we run a pre-benchmark test and want to leave some slack
+    rets = [el.get(timeout=180) for el in rets]
 
     # For multi-GPU benchmarking, only rank 0 has meaningful stats
     failed_ranks = []

--- a/examples/gather/reference.py
+++ b/examples/gather/reference.py
@@ -1,0 +1,19 @@
+import torch
+from task import input_t, output_t
+from utils import verbose_allclose
+from typing import Tuple
+
+
+def generate_input(seed: int, world_size: int, rank: int) -> input_t:
+    local_data = torch.tensor([rank]).to(f"cuda:{rank}")
+    return local_data, rank, world_size
+
+
+def check_implementation(data: input_t, output: output_t) -> Tuple[bool, str]:
+    data, rank, world_size = data
+    for i in range(world_size):
+        if output[i].get_device() != rank:
+            return False, f"mismatch found! output {i} of rank {rank} is on device {output[i].device}"
+        if (item := output[i].cpu().detach().item()) != i:
+            return False, f"mismatch found! custom implementation doesn't match reference: rank {rank}, entry {i} has value {item}"
+    return True, ''

--- a/examples/gather/submission.py
+++ b/examples/gather/submission.py
@@ -1,0 +1,12 @@
+#!POPCORN leaderboard identity_py-dev
+
+from task import input_t, output_t
+import torch
+from torch import distributed as dist
+
+
+def custom_kernel(data: input_t) -> output_t:
+    data, rank, world_size = data
+    result = [torch.empty_like(data) for _ in range(dist.get_world_size())]
+    dist.all_gather(result, data)
+    return result

--- a/examples/gather/task.py
+++ b/examples/gather/task.py
@@ -1,0 +1,10 @@
+from typing import TypedDict, List, Tuple
+import torch
+
+
+input_t = Tuple[torch.Tensor, int, int]
+output_t = List[torch.Tensor]
+
+
+class TestSpec(TypedDict):
+    pass

--- a/examples/gather/task.yml
+++ b/examples/gather/task.yml
@@ -1,0 +1,28 @@
+# name: identity-py
+
+files:
+  - {"name": "submission.py", "source": "@SUBMISSION@"}
+  - {"name": "task.py", "source": "task.py"}
+  - {"name": "utils.py", "source": "../utils.py"}
+  - {"name": "reference.py", "source": "reference.py"}
+  - {"name": "eval.py", "source": "../eval.py"}
+
+lang: "py"
+multi_gpu: true
+description:
+  A simple test task - python
+
+config:
+  main: "eval.py"
+
+templates:
+  Python: "../template.py"
+
+# small test cases. should be cheap to run.
+tests:
+  - {"seed": 5, "world_size": 4}
+
+benchmarks:
+  - {"seed": 10}
+
+ranking_by: "geom"

--- a/examples/gather/task.yml
+++ b/examples/gather/task.yml
@@ -23,6 +23,6 @@ tests:
   - {"seed": 5, "world_size": 4}
 
 benchmarks:
-  - {"seed": 10}
+  - {"seed": 10, "world_size": 4}
 
 ranking_by: "geom"

--- a/examples/gather/wrong.py
+++ b/examples/gather/wrong.py
@@ -1,0 +1,11 @@
+#!POPCORN leaderboard identity_py-dev
+
+from task import input_t, output_t
+import torch
+from torch import distributed as dist
+
+
+def custom_kernel(data: input_t) -> output_t:
+    data, rank, world_size = data
+    result = [torch.ones_like(data) for _ in range(dist.get_world_size())]
+    return result

--- a/src/libkernelbot/consts.py
+++ b/src/libkernelbot/consts.py
@@ -28,6 +28,8 @@ class ModalGPU(Enum):
     A100 = "A100"
     H100 = "H100"
     B200 = "B200"
+    # multi-gpu
+    L4x4 = "L4x4"
 
 
 @dataclasses.dataclass
@@ -109,7 +111,8 @@ class RankCriterion(Enum):
 
 GPU_TO_SM = {
     "T4": "75",
-    "L4": "80",
+    "L4": "89",
+    "L4x4": "89",
     "A100": "80",
     "H100": "90a",
     "B200": "100",

--- a/src/libkernelbot/run_eval.py
+++ b/src/libkernelbot/run_eval.py
@@ -218,7 +218,9 @@ def compile_cuda_script(  # # noqa: C901
     )
 
 
-def run_program(args: list[str], seed: Optional[int], timeout: int, multi_gpu: bool = False) -> RunResult:
+def run_program(
+    args: list[str], seed: Optional[int], timeout: int, multi_gpu: bool = False
+) -> RunResult:
     print("[Running]")
     # set up a pipe so the tester can communicate its verdict with us
     env = os.environ.copy()
@@ -229,6 +231,7 @@ def run_program(args: list[str], seed: Optional[int], timeout: int, multi_gpu: b
 
     if multi_gpu:
         import torch
+
         env["POPCORN_GPUS"] = str(torch.cuda.device_count())
 
     execution_start_time = time.perf_counter()
@@ -302,7 +305,9 @@ def run_single_evaluation(
         with tempfile.NamedTemporaryFile("w") as tests_file:
             tests_file.write(tests)
             tests_file.flush()
-            return run_program(call + [mode, tests_file.name], seed=seed, timeout=test_timeout, multi_gpu=multi_gpu)
+            return run_program(
+                call + [mode, tests_file.name], seed=seed, timeout=test_timeout, multi_gpu=multi_gpu
+            )
     elif mode in ["benchmark", "profile", "leaderboard"]:
         timeout = ranked_timeout if mode == "leaderboard" else benchmark_timeout
         with tempfile.NamedTemporaryFile("w") as bench_file:
@@ -311,7 +316,9 @@ def run_single_evaluation(
             else:
                 bench_file.write(benchmarks)
             bench_file.flush()
-            return run_program(call + [mode, bench_file.name], seed=seed, timeout=timeout, multi_gpu=multi_gpu)
+            return run_program(
+                call + [mode, bench_file.name], seed=seed, timeout=timeout, multi_gpu=multi_gpu
+            )
     else:
         raise ValueError(f"Invalid mode {mode}")
 

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -61,6 +61,7 @@ class LeaderboardTask:
     ranked_timeout: int = 180
     ranking_by: RankCriterion = RankCriterion.LAST
     seed: Optional[int] = None
+    multi_gpu: bool = False
 
     def __post_init__(self):
         if self.lang == Language.Python and not isinstance(self.config, PythonTaskData):
@@ -75,6 +76,7 @@ class LeaderboardTask:
         criterion = RankCriterion(data.get("ranking_by", RankCriterion.LAST))
         data_["lang"] = lang
         data_["ranking_by"] = criterion
+        data_["multi_gpu"] = data.get("multi_gpu", False)
         if lang == Language.Python:
             data_["config"] = PythonTaskData(**data["config"])
         else:
@@ -176,6 +178,7 @@ def build_task_config(
         "ranked_timeout": task.ranked_timeout,
         "ranking_by": task.ranking_by.value,
         "seed": task.seed,
+        "multi_gpu": task.multi_gpu,
     }
 
     if task.lang == Language.Python:

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -114,7 +114,7 @@ class LeaderboardDefinition:
     templates: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
-def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
+def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:  # noqa: C901
     if Path(yaml_file).is_dir():
         yaml_file = Path(yaml_file) / "task.yml"
 

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -151,6 +151,15 @@ def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
     description = raw["description"]
     del raw["description"]
     task = LeaderboardTask.from_dict(raw)
+
+    # basic validation:
+    if task.multi_gpu:
+        for test in task.tests:
+            if "world_size" not in test:
+                raise KernelBotError(f"multi-gpu test {test} does not specify world_size")
+        for benchmark in task.benchmarks:
+            if "world_size" not in benchmark:
+                raise KernelBotError(f"multi-gpu benchmark {benchmark} does not specify world_size")
     return LeaderboardDefinition(task=task, templates=templates, description=description)
 
 

--- a/src/runners/modal_runner.py
+++ b/src/runners/modal_runner.py
@@ -40,7 +40,7 @@ cuda_image = (
     )
     # other frameworks
     .pip_install(
-        "jax[cuda12]==0.5.3",   # 0.6 want's cudnn 9.8 in conflict with torch 2.7
+        "jax[cuda12]==0.5.3",  # 0.6 want's cudnn 9.8 in conflict with torch 2.7
         "jax2torch==0.0.7",
         "tinygrad~=0.10",
     )
@@ -50,8 +50,8 @@ cuda_image = (
         "nvidia-cutlass-dsl~=4.0",
         "cuda-core[cu12]~=0.3",
         "cuda-python[all]==12.8",
-        #"nvmath-python[cu12]~=0.4",
-        #"numba-cuda[cu12]~=0.15",
+        # "nvmath-python[cu12]~=0.4",
+        # "numba-cuda[cu12]~=0.15",
     )
 )
 

--- a/src/runners/modal_runner_archs.py
+++ b/src/runners/modal_runner_archs.py
@@ -2,9 +2,9 @@
 # Modal apps on specific devices. We will fix this later.
 from modal_runner import app, cuda_image, modal_run_config
 
-gpus = ["T4", "L4", "A100-80GB", "H100!", "B200"]
+gpus = ["T4", "L4", "L4:4", "A100-80GB", "H100!", "B200"]
 for gpu in gpus:
-    gpu_slug = gpu.lower().split("-")[0].strip("!")
+    gpu_slug = gpu.lower().split("-")[0].strip("!").replace(":", "x")
     app.function(gpu=gpu, image=cuda_image, name=f"run_cuda_script_{gpu_slug}", serialized=True)(
         modal_run_config
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,32 @@ templates:
   CUDA: "template.cu"
 """
 
+MULTi_GPU_TASK_YAML = """
+lang: py
+description: "Test task description"
+ranking_by: geom
+multi_gpu: true
+test_timeout: 120
+files:
+  - name: "kernel.py"
+    source: "kernel.py"
+  - name: "submission.py"
+    source: "@SUBMISSION@"
+config:
+  main: "kernel.py"
+tests:
+  - input_size: 1000
+    world_size: 4
+    dtype: "float32"
+benchmarks:
+  - input_size: 10000
+    world_size: 4
+    dtype: "float32"
+templates:
+  Python: "template.py"
+  CUDA: "template.cu"
+"""
+
 
 @pytest.fixture
 def task_directory(tmp_path):
@@ -117,6 +143,7 @@ def task_directory(tmp_path):
 
     # Create task.yml
     Path.write_text(tmp_path / "task.yml", TASK_YAML)
+    Path.write_text(tmp_path / "multi-task.yml", MULTi_GPU_TASK_YAML)
     return tmp_path
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -99,6 +99,7 @@ async def test_handle_submission(bot: backend.KernelBackend, task_directory):
         "lang": "py",
         "main": "kernel.py",
         "mode": "leaderboard",
+        "multi_gpu": False,
         "ranked_timeout": 180,
         "ranking_by": "geom",
         "seed": None,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -153,6 +153,7 @@ async def test_submit_leaderboard(bot: backend.KernelBackend, task_directory):
         "lang": "py",
         "main": "kernel.py",
         "mode": "leaderboard",
+        "multi_gpu": False,
         "ranked_timeout": 180,
         "ranking_by": "geom",
         "seed": 1337,
@@ -206,6 +207,7 @@ async def test_submit_leaderboard(bot: backend.KernelBackend, task_directory):
                     "start_time": eval_result.start.replace(tzinfo=datetime.timezone.utc),
                     "system": {
                         "cpu": "Intel i9-12900K",
+                        "device_count": 1,
                         "gpu": "NVIDIA RTX 4090",
                         "platform": "Linux-5.15.0",
                         "torch": "2.0.1+cu118",
@@ -310,6 +312,7 @@ async def test_submit_full(bot: backend.KernelBackend, task_directory):
                     "start_time": ANY,
                     "system": {
                         "cpu": "Intel i9-12900K",
+                        "device_count": 1,
                         "gpu": "NVIDIA RTX 4090",
                         "platform": "Linux-5.15.0",
                         "torch": "2.0.1+cu118",
@@ -351,6 +354,7 @@ async def test_submit_full(bot: backend.KernelBackend, task_directory):
                     "start_time": ANY,
                     "system": {
                         "cpu": "Intel i9-12900K",
+                        "device_count": 1,
                         "gpu": "NVIDIA RTX 4090",
                         "platform": "Linux-5.15.0",
                         "torch": "2.0.1+cu118",

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -240,6 +240,60 @@ async def test_modal_multi_gpu(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.parametrize("script, good", [("submission.py", True), ("wrong.py", False)])
+async def test_modal_multi_gpu_benchmark(
+    modal_deployment, project_root: Path, script: str, good: bool
+):
+    """
+    This isn't really a modal test, but instead a test using modal to check that multi-gpu submission
+    testing works (on modal...).
+    """
+    launcher = ModalLauncher(add_include_dirs=[])
+    reporter = MockProgressReporter("progress")
+
+    # Load the real identity_py task
+    task_path = project_root / "examples" / "gather"
+    if not task_path.exists():
+        pytest.skip("examples/gather not found - skipping Modal multi-gpu test")
+
+    # Load the task definition
+    task_definition = make_task_definition(task_path)
+
+    # Use the actual working submission from the examples
+    submission_content = (task_path / script).read_text()
+
+    config = build_task_config(
+        task=task_definition.task,
+        submission_content=submission_content,
+        arch=GPU_TO_SM[ModalGPU.L4x4.name],
+        mode=SubmissionMode.BENCHMARK,
+    )
+
+    result = await launcher.run_submission(config, ModalGPU.L4x4, reporter)
+
+    # Basic structure and success
+    assert result.success, f"Expected successful run, got: {result.error}"
+    assert result.error == ""
+    assert isinstance(result.runs, dict)
+
+    # System info - test actual expected values
+    pprint.pprint(result)
+    assert result.system.device_count == 4
+
+    # Test run structure
+    assert "benchmark" in result.runs
+    bench_run = result.runs["benchmark"]
+
+    # For Python runs, compilation is None
+    assert bench_run.compilation is None
+
+    # Run needs to succeed
+    assert bench_run.run.success is True
+    assert bench_run.run.passed is good
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 @pytest.mark.parametrize("script", ["cheat-fd.py", "cheat-input.py", "cheat-rng.py"])
 async def test_modal_launcher_failing_script(modal_deployment, project_root: Path, script: str):
     """

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -187,12 +187,10 @@ async def test_modal_launcher_python_script(
 @pytest.mark.integration
 @pytest.mark.asyncio
 @pytest.mark.parametrize("script, good", [("submission.py", True), ("wrong.py", False)])
-async def test_modal_multi_gpu(
-    modal_deployment, project_root: Path, script: str, good: bool
-):
+async def test_modal_multi_gpu(modal_deployment, project_root: Path, script: str, good: bool):
     """
-    This isn't really a modal test, but instead a test using modal to check that multi-gpu submission
-    testing works (on modal...).
+    This isn't really a modal test, but instead a test using modal to check
+    that multi-gpu submission testing works (on modal...).
     """
     launcher = ModalLauncher(add_include_dirs=[])
     reporter = MockProgressReporter("progress")
@@ -245,8 +243,8 @@ async def test_modal_multi_gpu_benchmark(
     modal_deployment, project_root: Path, script: str, good: bool
 ):
     """
-    This isn't really a modal test, but instead a test using modal to check that multi-gpu submission
-    testing works (on modal...).
+    This isn't really a modal test, but instead a test using modal
+    to check that multi-gpu submission testing works (on modal...).
     """
     launcher = ModalLauncher(add_include_dirs=[])
     reporter = MockProgressReporter("progress")


### PR DESCRIPTION
Implement multi-gpu tasks:
design: 
run_eval still calls only a single instance of eval.py, but if the task is multi-gpu, eval.py will create a pool of multiple worker processes, and call the user op on each with a different rank argument.

in the current code, input generation and testing is also handled by each process independently; I'm not sure if that's the right approach.