### PR TITLE
Increase wait time to 10

### DIFF
--- a/src/libkernelbot/launchers/github.py
+++ b/src/libkernelbot/launchers/github.py
@@ -221,7 +221,7 @@ class GitHubRun:
         )
 
         if success:
-            wait_seconds = 5
+            wait_seconds = 10
             logger.info(
                 f"Workflow dispatch successful. Waiting {wait_seconds}s for the run to appear..."
             )


### PR DESCRIPTION
We sometimes still happen to end up with `could not find a job with name ....` when running GH runs, might be that the sleep is too tight for github api to propagate the changes, idk.