### PR TITLE
Fix: remove tzinfo

### DIFF
--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -81,7 +81,6 @@ class LeaderboardDB:
         gpu_types: list | str,
     ) -> int:
         # to prevent surprises, ensure we have specified a timezone
-        assert deadline.tzinfo is not None
         try:
             task = definition.task
             self.cursor.execute(
@@ -260,16 +259,13 @@ class LeaderboardDB:
                 (identifier,),
             )
             row = self.cursor.fetchone()
-            return {
-                "user_id": row[0],
-                "user_name": row[1],
-                "id_type":id_type.value
-            } if row else None
+            return (
+                {"user_id": row[0], "user_name": row[1], "id_type": id_type.value} if row else None
+            )
         except psycopg2.Error as e:
             self.connection.rollback()
             logger.exception("Error validating %s %s", human_label, identifier, exc_info=e)
             raise KernelBotError(f"Error validating {human_label}") from e
-
 
     def create_submission(
         self,
@@ -389,7 +385,6 @@ class LeaderboardDB:
             self.connection.rollback()
             logger.error("Failed to upsert submission job status. sub_id: '%s'", sub_id, exc_info=e)
             raise KernelBotError("Error updating job status") from e
-
 
     def upsert_submission_job_status(
         self,


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes in this pull request.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
