### PR TITLE
fix example submission names

### DIFF
--- a/examples/gather/submission.py
+++ b/examples/gather/submission.py
@@ -1,4 +1,4 @@
-#!POPCORN leaderboard identity_py-dev
+#!POPCORN leaderboard gather-dev
 
 from task import input_t, output_t
 import torch

--- a/examples/gather/wrong.py
+++ b/examples/gather/wrong.py
@@ -1,4 +1,4 @@
-#!POPCORN leaderboard identity_py-dev
+#!POPCORN leaderboard gather-dev
 
 from task import input_t, output_t
 import torch

--- a/examples/matmul_py/submission.py
+++ b/examples/matmul_py/submission.py
@@ -1,4 +1,4 @@
-#!POPCORN leaderboard matmul_py
+#!POPCORN leaderboard matmul_py-dev
 
 from task import input_t, output_t
 

--- a/examples/softmax_py/submission.py
+++ b/examples/softmax_py/submission.py
@@ -1,4 +1,4 @@
-#!POPCORN leaderboard softmax_py
+#!POPCORN leaderboard softmax_py-dev
 
 import torch
 from task import input_t, output_t

--- a/examples/vectoradd_py/submission_cuda_inline.py
+++ b/examples/vectoradd_py/submission_cuda_inline.py
@@ -1,4 +1,4 @@
-#!POPCORN leaderboard vectoradd_py
+#!POPCORN leaderboard vectoradd_py-dev
 
 import torch
 from torch.utils.cpp_extension import load_inline

--- a/examples/vectoradd_py/submission_triton.py
+++ b/examples/vectoradd_py/submission_triton.py
@@ -1,4 +1,4 @@
-#!POPCORN leaderboard vectoradd_py
+#!POPCORN leaderboard vectoradd_py-dev
 
 import torch
 import triton


### PR DESCRIPTION
## Description

This fixes all the example leaderboard names: Some were not using the -dev variant, some were not using the right leaderboard name at all. Since during experimentation the leaderboard automatically creates a `-dev` leaderboard, I figured it would be easiest to also use the `-dev` variant here so that we don't need to change the name when submitting an example benchmark.

Extracted from !339 as per request

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
