### PR TITLE
Increase default timeout in modal_run_config

### DIFF
--- a/src/runners/modal_runner.py
+++ b/src/runners/modal_runner.py
@@ -87,7 +87,7 @@ def timeout(seconds: int):
 
 def modal_run_config(  # noqa: C901
     config: dict,
-    timeout_seconds: int = 300,
+    timeout_seconds: int = 600,
 ) -> FullResult:
     """Modal version of run_pytorch_script, handling timeouts"""
     try:


### PR DESCRIPTION
Increased the default timeout for modal_run_config from 300 to 600 seconds.

## Description

Please provide a brief summary of the changes in this pull request.

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
