### PR TITLE
Update default timeout in modal_run_config

### DIFF
--- a/src/runners/modal_runner.py
+++ b/src/runners/modal_runner.py
@@ -87,7 +87,7 @@ def timeout(seconds: int):
 
 def modal_run_config(  # noqa: C901
     config: dict,
-    timeout_seconds: int = 300,
+    timeout_seconds: int = 600,
 ) -> FullResult:
     """Modal version of run_pytorch_script, handling timeouts"""
     try:


### PR DESCRIPTION
Increased the default timeout from 300 to 600 seconds.